### PR TITLE
feat: redesign DatasetDetail with tabbed interface and enriched data model

### DIFF
--- a/src/components/dataset-detail/AccessTab.jsx
+++ b/src/components/dataset-detail/AccessTab.jsx
@@ -1,0 +1,129 @@
+const ACCESS_MODEL_INFO = {
+  a2d: {
+    label: 'Algorithm to Data (A2D)',
+    description:
+      'Your algorithm is executed on the data within the secure environment. You receive only the results, never the raw data.',
+    icon: (
+      <svg className="w-6 h-6 text-teal-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Zm.75-12h9v9h-9v-9Z" />
+      </svg>
+    ),
+  },
+  'data-behind-glass': {
+    label: 'Data Behind Glass (Glass Sandbox)',
+    description:
+      'View and analyze data within a secure Glass Sandbox environment. No data can be downloaded or exported.',
+    icon: (
+      <svg className="w-6 h-6 text-teal-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25A2.25 2.25 0 0 1 5.25 3h13.5A2.25 2.25 0 0 1 21 5.25Z" />
+      </svg>
+    ),
+  },
+  'metadata-light': {
+    label: 'Metadata Light',
+    description:
+      'Access to detailed metadata and aggregate statistics. No individual-level data access.',
+    icon: (
+      <svg className="w-6 h-6 text-teal-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+      </svg>
+    ),
+  },
+};
+
+function formatAccessLevel(model) {
+  const info = ACCESS_MODEL_INFO[model];
+  return info ? info.label : model;
+}
+
+export default function AccessTab({ dataset }) {
+  const primaryModel = dataset.accessModels?.[0];
+
+  return (
+    <div className="space-y-6">
+      {/* Header Card */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">Access & Compliance</h3>
+        <p className="text-gray-600 text-sm leading-relaxed">
+          Access to this dataset ({formatAccessLevel(primaryModel)}) is governed by the
+          Health Data Innovation Platform (HDIP) framework and relevant Swedish regulations.
+          Access typically requires review and approval by a Data Access Committee (DAC) and
+          use within a designated Glass Sandbox environment.
+        </p>
+      </div>
+
+      {/* General Compliance Points */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h4 className="font-semibold text-gray-900 mb-4">General Compliance Requirements</h4>
+        <ul className="space-y-3">
+          {[
+            'A formal application and approval by the relevant Data Access Committee (DAC) is required.',
+            'Data analysis must be conducted within an approved Glass Sandbox environment.',
+            'Strict adherence to GDPR, the Swedish Patient Data Act, and the Ethical Review Act is mandatory.',
+            'A Data Use Agreement (DUA) must be signed before access is granted.',
+          ].map((point, i) => (
+            <li key={i} className="flex items-start gap-3">
+              <svg
+                className="w-5 h-5 text-teal-600 shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+              </svg>
+              <span className="text-gray-600 text-sm">{point}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Access Model Cards */}
+      {dataset.accessModels?.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h4 className="font-semibold text-gray-900 mb-4">Available Access Models</h4>
+          <div className="space-y-3">
+            {dataset.accessModels.map((model) => {
+              const info = ACCESS_MODEL_INFO[model];
+              if (!info) return null;
+              return (
+                <div
+                  key={model}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-4 flex items-start gap-3"
+                >
+                  {info.icon}
+                  <div>
+                    <p className="font-bold text-gray-900">{info.label}</p>
+                    <p className="text-gray-600 text-sm mt-1">{info.description}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Links */}
+      <div className="flex flex-wrap gap-4">
+        <a
+          href="#"
+          className="inline-flex items-center gap-1.5 text-teal-600 hover:text-teal-700 text-sm font-medium"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+          </svg>
+          View Platform Ethical Guidelines
+        </a>
+        <a
+          href="#"
+          className="inline-flex items-center gap-1.5 text-teal-600 hover:text-teal-700 text-sm font-medium"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+          </svg>
+          Overview of Relevant Regulations
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dataset-detail/DatasetHeader.jsx
+++ b/src/components/dataset-detail/DatasetHeader.jsx
@@ -1,0 +1,212 @@
+import { Link } from 'react-router-dom';
+
+const ACCESS_MODEL_LABELS = {
+  a2d: 'Algorithm to Data',
+  'data-behind-glass': 'Controlled',
+  'metadata-light': 'Metadata Only',
+};
+
+const SENSITIVITY_STYLES = {
+  'Special Category': {
+    wrapper: 'bg-red-100 text-red-700 border border-red-200',
+    icon: (
+      <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.751h-.152c-3.196 0-6.1-1.25-8.25-3.286ZM12 15.75h.008v.008H12v-.008Z" />
+      </svg>
+    ),
+  },
+  Pseudonymized: {
+    wrapper: 'bg-amber-100 text-amber-700 border border-amber-200',
+    icon: (
+      <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.751h-.152c-3.196 0-6.1-1.25-8.25-3.286Z" />
+      </svg>
+    ),
+  },
+  Anonymized: {
+    wrapper: 'bg-green-100 text-green-700 border border-green-200',
+    icon: (
+      <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.751h-.152c-3.196 0-6.1-1.25-8.25-3.286Z" />
+      </svg>
+    ),
+  },
+  Aggregated: {
+    wrapper: 'bg-blue-100 text-blue-700 border border-blue-200',
+    icon: (
+      <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.751h-.152c-3.196 0-6.1-1.25-8.25-3.286Z" />
+      </svg>
+    ),
+  },
+};
+
+function formatCategory(cat) {
+  return cat
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+export default function DatasetHeader({
+  dataset,
+  isAuthenticated,
+  currentUser,
+  bookmarked,
+  onToggleBookmark,
+  onRequestAccess,
+}) {
+  const firstAccessModel = dataset.accessModels?.[0];
+  const accessLabel = ACCESS_MODEL_LABELS[firstAccessModel] || firstAccessModel;
+  const sensitivity = dataset.sensitivityLevel
+    ? SENSITIVITY_STYLES[dataset.sensitivityLevel]
+    : null;
+
+  const canRequestAccess =
+    isAuthenticated &&
+    (currentUser?.role === 'data-user' || currentUser?.role === 'admin');
+  const isHolder = isAuthenticated && currentUser?.role === 'data-holder';
+  const canBookmark =
+    isAuthenticated &&
+    (currentUser?.role === 'data-user' || currentUser?.role === 'admin');
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-1.5 text-sm text-gray-500">
+        <Link to="/" className="hover:text-gray-700">
+          <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+          </svg>
+        </Link>
+        <span>&gt;</span>
+        <Link to="/catalog" className="hover:text-gray-700 hover:underline">
+          Datasets
+        </Link>
+        <span>&gt;</span>
+        <span className="text-gray-900 font-medium truncate max-w-xs">
+          {dataset.title}
+        </span>
+      </nav>
+
+      {/* Title */}
+      <h1 className="text-3xl font-bold text-gray-900 mt-3">{dataset.title}</h1>
+
+      {/* Provider line */}
+      <p className="text-sm text-gray-600 mt-2">
+        Provided by:{' '}
+        <Link
+          to={`/providers/${dataset.holder.id}`}
+          className="text-teal-600 hover:underline font-medium"
+        >
+          {dataset.holder.name}
+        </Link>
+      </p>
+
+      {/* Description */}
+      <p className="text-gray-500 mt-1">{dataset.description}</p>
+
+      {/* Metadata badges */}
+      <div className="flex flex-wrap gap-2 mt-4">
+        {/* ID */}
+        <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm bg-gray-100 text-gray-600">
+          <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" />
+          </svg>
+          {dataset.id}
+        </span>
+
+        {/* Type / Category */}
+        <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm bg-gray-100 text-gray-600">
+          <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L12 12.75l-5.571-3m11.142 0L21.75 12l-4.179 2.25m0 0L12 17.25l-5.571-3m11.142 0L21.75 16.5 12 21.75 2.25 16.5l4.179-2.25" />
+          </svg>
+          {formatCategory(dataset.category)}
+        </span>
+
+        {/* Access model */}
+        {firstAccessModel && (
+          <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm bg-gray-100 text-gray-600">
+            <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+            </svg>
+            {accessLabel}
+          </span>
+        )}
+
+        {/* FAIR Score */}
+        <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm bg-gray-100 text-gray-600">
+          <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          </svg>
+          FAIR Score: {dataset.fairScore.total}
+        </span>
+
+        {/* Sensitivity */}
+        {dataset.sensitivityLevel && sensitivity && (
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm ${sensitivity.wrapper}`}
+          >
+            {sensitivity.icon}
+            {dataset.sensitivityLevel}
+          </span>
+        )}
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-3 mt-5">
+        {/* Request Access */}
+        {!isAuthenticated && (
+          <Link
+            to="/login"
+            className="inline-flex items-center gap-2 rounded-lg border border-teal-600 px-5 py-2.5 text-sm font-medium text-teal-700 hover:bg-teal-50 transition-colors"
+          >
+            <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
+            </svg>
+            Log in to request access
+          </Link>
+        )}
+        {canRequestAccess && !isHolder && (
+          <button
+            onClick={onRequestAccess}
+            className="bg-teal-600 hover:bg-teal-700 text-white px-5 py-2.5 rounded-lg font-medium inline-flex items-center gap-2 transition-colors"
+          >
+            <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+            </svg>
+            Request Access
+          </button>
+        )}
+
+        {/* Save for Later / Bookmark */}
+        {canBookmark && (
+          <button
+            onClick={onToggleBookmark}
+            className={`inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+              bookmarked
+                ? 'border border-teal-200 bg-teal-50 text-teal-600'
+                : 'border border-gray-300 text-gray-700 hover:border-gray-400'
+            }`}
+          >
+            <svg
+              className="w-4 h-4"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill={bookmarked ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              strokeWidth={bookmarked ? 0 : 1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z"
+              />
+            </svg>
+            {bookmarked ? 'Saved' : 'Save for Later'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dataset-detail/DatasetSidebar.jsx
+++ b/src/components/dataset-detail/DatasetSidebar.jsx
@@ -1,0 +1,61 @@
+import { Link } from 'react-router-dom';
+
+export default function DatasetSidebar({ dataset, relatedDatasets }) {
+  return (
+    <div className="space-y-6">
+      {/* Data Provider Card */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm text-center">
+        <div className="bg-gray-100 rounded-full p-3 mx-auto mb-3 w-14 h-14 flex items-center justify-center">
+          <svg
+            className="w-8 h-8 text-gray-400"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"
+            />
+          </svg>
+        </div>
+        <Link
+          to={`/providers/${dataset.holder.id}`}
+          className="text-teal-600 font-semibold text-lg hover:underline"
+        >
+          {dataset.holder.name}
+        </Link>
+        <p className="text-sm text-gray-500 mt-2">
+          Official provider of this dataset. Click to view more datasets from
+          them.
+        </p>
+      </div>
+
+      {/* Related Datasets Card */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="font-semibold text-gray-900 mb-3">Related Datasets</h3>
+        {relatedDatasets && relatedDatasets.length > 0 ? (
+          <ul className="space-y-2.5">
+            {relatedDatasets.map((ds) => (
+              <li key={ds.id}>
+                <Link
+                  to={`/catalog/${ds.id}`}
+                  className="text-teal-600 hover:text-teal-700 text-sm"
+                >
+                  {ds.title}{' '}
+                  <span className="text-gray-400">(ID: {ds.id})</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-400 text-sm italic">
+            No related datasets found.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dataset-detail/DetailsTab.jsx
+++ b/src/components/dataset-detail/DetailsTab.jsx
@@ -1,0 +1,459 @@
+import { getFairLabel, getFairColor } from '../../utils/fairScore';
+
+const FAIR_DIMENSIONS = [
+  { key: 'findable', label: 'Findable' },
+  { key: 'accessible', label: 'Accessible' },
+  { key: 'interoperable', label: 'Interoperable' },
+  { key: 'reusable', label: 'Reusable' },
+];
+
+const SENSITIVITY_STYLES = {
+  'Special Category': { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200' },
+  'Pseudonymized': { bg: 'bg-amber-50', text: 'text-amber-700', border: 'border-amber-200' },
+  'Anonymized': { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200' },
+  'Aggregated': { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-200' },
+};
+
+function formatCategory(cat) {
+  if (!cat) return 'N/A';
+  return cat
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function formatAccessModel(model) {
+  const labels = {
+    a2d: 'Algorithm to Data (A2D)',
+    'data-behind-glass': 'Data Behind Glass',
+    'metadata-light': 'Metadata Light',
+  };
+  return labels[model] || formatCategory(model);
+}
+
+export default function DetailsTab({ dataset }) {
+  const fairScore = dataset.fairScore || {};
+  const totalScore = fairScore.total || 0;
+  const maxPerDimension = 5;
+
+  const sensitivityStyle = SENSITIVITY_STYLES[dataset.sensitivityLevel] || {
+    bg: 'bg-gray-50',
+    text: 'text-gray-700',
+    border: 'border-gray-200',
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      {/* Core Information */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Core Information
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {/* Data Type */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 6h.008v.008H6V6Z"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Data Type
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {formatCategory(dataset.category)}
+              </p>
+            </div>
+          </div>
+
+          {/* Record Count */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 12c0-.621.504-1.125 1.125-1.125m0 3.75h7.5"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Record Count
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.recordCount
+                  ? dataset.recordCount.toLocaleString()
+                  : 'N/A'}
+              </p>
+            </div>
+          </div>
+
+          {/* Timespan */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Timespan
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.dateRange
+                  ? `${new Date(dataset.dateRange.from).getFullYear()} - ${new Date(dataset.dateRange.to).getFullYear()}`
+                  : 'N/A'}
+              </p>
+            </div>
+          </div>
+
+          {/* Last Updated */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Last Updated
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.createdAt
+                  ? new Date(dataset.createdAt).toLocaleDateString('en-SE', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })
+                  : 'N/A'}
+              </p>
+            </div>
+          </div>
+
+          {/* Update Frequency */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Update Frequency
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.updateFrequency || 'Not specified'}
+              </p>
+            </div>
+          </div>
+
+          {/* Geographic Coverage */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Geographic Coverage
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.geographicCoverage || 'Not specified'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Governance & Compliance */}
+      <div className="border-t border-gray-100 pt-6 mt-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Governance &amp; Compliance
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {/* Sensitivity Level */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Sensitivity Level
+              </p>
+              <div className="mt-1">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold border ${sensitivityStyle.bg} ${sensitivityStyle.text} ${sensitivityStyle.border}`}
+                >
+                  {dataset.sensitivityLevel || 'Not specified'}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* License */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                License
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.license || 'Not specified'}
+              </p>
+            </div>
+          </div>
+
+          {/* Access Level */}
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <svg
+                className="h-5 w-5 text-teal-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+                />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Access Level
+              </p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {dataset.accessModels && dataset.accessModels.length > 0
+                  ? formatAccessModel(dataset.accessModels[0])
+                  : 'Not specified'}
+              </p>
+            </div>
+          </div>
+
+          {/* Data Standards */}
+          {dataset.dataStandards && dataset.dataStandards.length > 0 && (
+            <div className="col-span-2 md:col-span-3 flex items-start gap-3">
+              <div className="shrink-0 mt-0.5">
+                <svg
+                  className="h-5 w-5 text-teal-600"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M4.745 3A23.933 23.933 0 0 0 3 12c0 3.183.62 6.22 1.745 9M19.5 3c.967 2.78 1.5 5.817 1.5 9s-.533 6.22-1.5 9M8.25 8.885l1.444-.89a.75.75 0 0 1 1.105.402l2.402 7.206a.75.75 0 0 0 1.104.401l1.445-.889m-8.25.75.213.09a1.687 1.687 0 0 0 2.062-.617l4.45-6.676a1.688 1.688 0 0 1 2.062-.618l.213.09"
+                  />
+                </svg>
+              </div>
+              <div>
+                <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1.5">
+                  Data Standards
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {dataset.dataStandards.map((std) => (
+                    <span
+                      key={std}
+                      className="inline-flex items-center rounded-full bg-teal-50 px-2.5 py-0.5 text-xs font-medium text-teal-700 border border-teal-200"
+                    >
+                      {std}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Quality & Provenance - FAIR Score */}
+      <div className="border-t border-gray-100 pt-6 mt-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Quality &amp; Provenance
+        </h3>
+
+        {/* Total FAIR Score */}
+        <div className="flex items-center gap-3 mb-5">
+          <span className="text-2xl font-bold text-gray-900">
+            {totalScore}
+          </span>
+          <span className="text-sm text-gray-500">/ 20</span>
+          <span
+            className={`ml-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${getFairColor(totalScore)} bg-teal-50`}
+          >
+            {getFairLabel(totalScore)}
+          </span>
+        </div>
+
+        {/* FAIR Dimension Bars */}
+        <div className="space-y-3">
+          {FAIR_DIMENSIONS.map(({ key, label }) => {
+            const score = fairScore[key] || 0;
+            const pct = (score / maxPerDimension) * 100;
+            return (
+              <div key={key}>
+                <div className="flex items-center justify-between text-sm mb-1">
+                  <span className="font-medium text-gray-700">{label}</span>
+                  <span className="text-gray-500">
+                    {score}/{maxPerDimension}
+                  </span>
+                </div>
+                <div className="h-2.5 w-full rounded-full bg-gray-100">
+                  <div
+                    className="h-2.5 rounded-full bg-teal-500 transition-all duration-500"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Documentation & Links - Columns */}
+      {dataset.columns && dataset.columns.length > 0 && (
+        <div className="border-t border-gray-100 pt-6 mt-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            Documentation &amp; Links
+          </h3>
+          <p className="text-sm text-gray-500 mb-2">
+            Columns ({dataset.columns.length})
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {dataset.columns.map((col) => (
+              <span
+                key={col}
+                className="bg-gray-100 text-gray-700 rounded px-2 py-1 text-xs font-mono"
+              >
+                {col}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Keywords */}
+      {dataset.tags && dataset.tags.length > 0 && (
+        <div className="border-t border-gray-100 pt-6 mt-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            Keywords
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {dataset.tags.map((tag) => (
+              <span
+                key={tag}
+                className="bg-teal-50 text-teal-700 border border-teal-200 rounded-full px-3 py-1 text-sm"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dataset-detail/DictionaryTab.jsx
+++ b/src/components/dataset-detail/DictionaryTab.jsx
@@ -1,0 +1,31 @@
+// eslint-disable-next-line no-unused-vars
+export default function DictionaryTab({ dataset }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm text-center">
+      <svg
+        className="w-12 h-12 mx-auto mb-4 text-gray-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+        />
+      </svg>
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">Data Dictionary</h3>
+      <p className="text-gray-500 mb-6 max-w-md mx-auto">
+        A comprehensive data dictionary with detailed column descriptions, data types,
+        value ranges, and coding schemas will be available here in a future release.
+      </p>
+      <button
+        disabled
+        className="bg-gray-100 text-gray-400 px-4 py-2 rounded-lg cursor-not-allowed"
+      >
+        View Dictionary (Coming Soon)
+      </button>
+    </div>
+  );
+}

--- a/src/components/dataset-detail/FaqTab.jsx
+++ b/src/components/dataset-detail/FaqTab.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+export default function FaqTab({ dataset }) {
+  const [openIndex, setOpenIndex] = useState(null);
+  const faq = dataset.faq || [];
+
+  if (faq.length === 0) {
+    return (
+      <p className="text-gray-400 italic text-sm">
+        No frequently asked questions have been added for this dataset yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm divide-y divide-gray-200">
+      {faq.map((item, index) => (
+        <div key={index}>
+          <button
+            onClick={() => setOpenIndex(openIndex === index ? null : index)}
+            className="w-full py-4 px-5 cursor-pointer flex justify-between items-center font-medium text-gray-900 hover:bg-gray-50 text-left"
+          >
+            <span>{item.question}</span>
+            <svg
+              className={`w-5 h-5 text-gray-400 shrink-0 ml-4 transition-transform duration-200 ${
+                openIndex === index ? 'rotate-180' : ''
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+            </svg>
+          </button>
+          {openIndex === index && (
+            <div className="px-5 pb-4 text-gray-600 text-sm">{item.answer}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dataset-detail/OverviewTab.jsx
+++ b/src/components/dataset-detail/OverviewTab.jsx
@@ -1,0 +1,256 @@
+export default function OverviewTab({ dataset }) {
+  const cohort = dataset.cohort;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      {/* Dataset Overview */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Dataset Overview
+        </h3>
+        <p className="text-gray-700 leading-relaxed">{dataset.description}</p>
+      </div>
+
+      {/* Purpose & Methodology */}
+      <div className="border-t border-gray-100 pt-6 mt-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Purpose &amp; Methodology
+        </h3>
+        <p className="text-gray-700 leading-relaxed">
+          {dataset.methodology || (
+            <span className="italic text-gray-400">Not available</span>
+          )}
+        </p>
+      </div>
+
+      {/* Limitations */}
+      <div className="border-t border-gray-100 pt-6 mt-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Limitations
+        </h3>
+        <p className="text-gray-700 leading-relaxed">
+          {dataset.limitations || (
+            <span className="italic text-gray-400">Not available</span>
+          )}
+        </p>
+      </div>
+
+      {/* Cohort Description */}
+      <div className="border-t border-gray-100 pt-6 mt-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Cohort Description
+        </h3>
+        {cohort ? (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+              <div className="rounded-lg bg-gray-50 p-3">
+                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Age Range
+                </dt>
+                <dd className="mt-1 text-sm font-semibold text-gray-900">
+                  {cohort.ageRange || 'N/A'}
+                </dd>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3">
+                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Sex Distribution
+                </dt>
+                <dd className="mt-1 text-sm font-semibold text-gray-900">
+                  {cohort.sexDistribution
+                    ? `Male ${cohort.sexDistribution.male}% / Female ${cohort.sexDistribution.female}%`
+                    : 'N/A'}
+                </dd>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3">
+                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Geographic Area
+                </dt>
+                <dd className="mt-1 text-sm font-semibold text-gray-900">
+                  {cohort.geographicArea || 'N/A'}
+                </dd>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3">
+                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Sample Size
+                </dt>
+                <dd className="mt-1 text-sm font-semibold text-gray-900">
+                  {cohort.sampleSize
+                    ? cohort.sampleSize.toLocaleString()
+                    : 'N/A'}
+                </dd>
+              </div>
+            </div>
+            {cohort.description && (
+              <p className="text-gray-700 leading-relaxed text-sm">
+                {cohort.description}
+              </p>
+            )}
+          </>
+        ) : (
+          <div className="rounded-lg bg-gray-50 p-6 text-center">
+            <svg
+              className="mx-auto h-8 w-8 text-gray-300 mb-2"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
+              />
+            </svg>
+            <p className="text-sm text-gray-400">
+              No cohort information available for this dataset.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Data Characteristics */}
+      {((dataset.dataTypes && dataset.dataTypes.length > 0) ||
+        (dataset.fileFormats && dataset.fileFormats.length > 0)) && (
+        <div className="border-t border-gray-100 pt-6 mt-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            Data Characteristics
+          </h3>
+          <div className="grid md:grid-cols-2 gap-6">
+            {/* Data Types */}
+            {dataset.dataTypes && dataset.dataTypes.length > 0 && (
+              <div>
+                <h4 className="text-sm font-medium text-gray-500 mb-2">
+                  Data Types
+                </h4>
+                <div className="flex flex-wrap gap-2">
+                  {dataset.dataTypes.map((type) => (
+                    <span
+                      key={type}
+                      className="bg-teal-50 text-teal-700 border border-teal-200 rounded-full px-3 py-1 text-sm"
+                    >
+                      {type}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {/* File Formats */}
+            {dataset.fileFormats && dataset.fileFormats.length > 0 && (
+              <div>
+                <h4 className="text-sm font-medium text-gray-500 mb-2">
+                  File Formats
+                </h4>
+                <div className="flex flex-wrap gap-2">
+                  {dataset.fileFormats.map((format) => (
+                    <span
+                      key={format}
+                      className="bg-gray-100 text-gray-700 rounded-full px-3 py-1 text-sm"
+                    >
+                      {format}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Key Figures */}
+      <div className="border-t border-gray-100 pt-6 mt-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Key Figures
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="rounded-lg bg-teal-50 p-4 text-center">
+            <svg
+              className="mx-auto h-5 w-5 text-teal-600 mb-1.5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 12c0-.621.504-1.125 1.125-1.125m0 3.75h7.5"
+              />
+            </svg>
+            <p className="text-xs font-medium text-gray-500">Record Count</p>
+            <p className="text-lg font-bold text-gray-900 mt-0.5">
+              {dataset.recordCount
+                ? dataset.recordCount.toLocaleString()
+                : 'N/A'}
+            </p>
+          </div>
+          <div className="rounded-lg bg-teal-50 p-4 text-center">
+            <svg
+              className="mx-auto h-5 w-5 text-teal-600 mb-1.5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
+              />
+            </svg>
+            <p className="text-xs font-medium text-gray-500">Dataset Size</p>
+            <p className="text-lg font-bold text-gray-900 mt-0.5">
+              {dataset.dataSize || 'N/A'}
+            </p>
+          </div>
+          <div className="rounded-lg bg-teal-50 p-4 text-center">
+            <svg
+              className="mx-auto h-5 w-5 text-teal-600 mb-1.5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+              />
+            </svg>
+            <p className="text-xs font-medium text-gray-500">Date Range</p>
+            <p className="text-lg font-bold text-gray-900 mt-0.5">
+              {dataset.dateRange
+                ? `${new Date(dataset.dateRange.from).getFullYear()} - ${new Date(dataset.dateRange.to).getFullYear()}`
+                : 'N/A'}
+            </p>
+          </div>
+          <div className="rounded-lg bg-teal-50 p-4 text-center">
+            <svg
+              className="mx-auto h-5 w-5 text-teal-600 mb-1.5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+              />
+            </svg>
+            <p className="text-xs font-medium text-gray-500">
+              Update Frequency
+            </p>
+            <p className="text-lg font-bold text-gray-900 mt-0.5">
+              {dataset.updateFrequency || 'N/A'}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dataset-detail/PublicationsTab.jsx
+++ b/src/components/dataset-detail/PublicationsTab.jsx
@@ -1,0 +1,58 @@
+export default function PublicationsTab({ dataset }) {
+  const publications = dataset.publications || [];
+
+  if (publications.length === 0) {
+    return (
+      <p className="text-gray-400 italic text-sm">
+        No publications have been linked to this dataset yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {publications.map((pub, index) => (
+        <div
+          key={index}
+          className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"
+        >
+          {pub.url ? (
+            <a
+              href={pub.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-600 hover:text-teal-700 font-semibold leading-snug"
+            >
+              {pub.title}
+            </a>
+          ) : (
+            <h4 className="font-semibold text-gray-900 leading-snug">{pub.title}</h4>
+          )}
+
+          {pub.authors && (
+            <p className="text-sm text-gray-600 mt-1">{pub.authors}</p>
+          )}
+
+          {(pub.journal || pub.year) && (
+            <p className="text-sm text-gray-500 italic mt-1">
+              {pub.journal}
+              {pub.journal && pub.year ? ', ' : ''}
+              {pub.year}
+            </p>
+          )}
+
+          {pub.doi && (
+            <a
+              href={`https://doi.org/${pub.doi}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-600 hover:text-teal-700 text-xs mt-2 inline-block"
+            >
+              DOI: {pub.doi}
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dataset-detail/SampleTab.jsx
+++ b/src/components/dataset-detail/SampleTab.jsx
@@ -1,0 +1,31 @@
+// eslint-disable-next-line no-unused-vars
+export default function SampleTab({ dataset }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm text-center">
+      <svg
+        className="w-12 h-12 mx-auto mb-4 text-gray-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 13.125c0-.621.504-1.125 1.125-1.125"
+        />
+      </svg>
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">Sample Data</h3>
+      <p className="text-gray-500 mb-6 max-w-md mx-auto">
+        Auto-generated masked and anonymized sample data will be available here in a future release.
+        Samples will be provided in multiple formats including CSV, JSON, and Parquet.
+      </p>
+      <button
+        disabled
+        className="bg-gray-100 text-gray-400 px-4 py-2 rounded-lg cursor-not-allowed"
+      >
+        Load Sample Data (Coming Soon)
+      </button>
+    </div>
+  );
+}

--- a/src/components/dataset-detail/UseCasesTab.jsx
+++ b/src/components/dataset-detail/UseCasesTab.jsx
@@ -1,0 +1,38 @@
+export default function UseCasesTab({ dataset }) {
+  const useCases = dataset.useCases || [];
+
+  if (useCases.length === 0) {
+    return (
+      <p className="text-gray-400 italic text-sm">
+        No use cases have been documented for this dataset yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {useCases.map((useCase, index) => (
+        <div
+          key={index}
+          className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"
+        >
+          <svg
+            className="w-8 h-8 text-teal-500 mb-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
+            />
+          </svg>
+          <h4 className="font-semibold text-gray-900 mb-1">{useCase.title}</h4>
+          <p className="text-gray-600 text-sm">{useCase.description}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/data/datasets.json
+++ b/src/data/datasets.json
@@ -16,7 +16,32 @@
     "geographicCoverage": "Vastra Gotalandsregionen",
     "fairScore": { "findable": 4, "accessible": 3, "interoperable": 3, "reusable": 2, "total": 12 },
     "createdAt": "2025-06-15",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Clinical/Journal"],
+    "fileFormats": ["CSV", "Parquet"],
+    "sensitivityLevel": "Pseudonymized",
+    "dataSize": "1.2 GB",
+    "updateFrequency": "Quarterly",
+    "methodology": "Data extracted from regional electronic health record systems (Melior/Millennium) via automated ETL pipelines. Patient identifiers replaced with cryptographic hashes. Diagnosis codes mapped to ICD-10-SE. Quality checks include admission-discharge date validation, duplicate record removal, and department code standardization.",
+    "limitations": "Excludes primary care visits and private outpatient clinics. Emergency department visits without subsequent admission are only partially captured before 2021. Some smaller clinics migrated EHR systems during the study period, causing a 3-month data gap for approximately 5% of departments.",
+    "cohort": {
+      "ageRange": "0-99",
+      "sexDistribution": { "male": 48, "female": 52 },
+      "geographicArea": "Vastra Gotalandsregionen",
+      "sampleSize": 245000,
+      "description": "All patients admitted to regional hospitals in VGR between 2019-2023, covering emergency, elective, and day-case admissions across all clinical departments. Includes pediatric and geriatric populations."
+    },
+    "useCases": [
+      { "title": "Resource Optimization", "description": "Analyze admission patterns and length of stay to optimize bed allocation and staffing across departments." },
+      { "title": "Bottleneck Identification", "description": "Identify patient flow bottlenecks between emergency departments and inpatient wards to reduce waiting times." }
+    ],
+    "publications": [
+      { "title": "Patient Flow Dynamics in Swedish Regional Hospitals: A Five-Year Analysis", "authors": "Svensson K, Andersson L, Johansson M", "journal": "Scandinavian Journal of Public Health", "year": 2024, "doi": "10.1177/14034948241234567", "url": "https://doi.org/10.1177/14034948241234567" }
+    ],
+    "faq": [
+      { "question": "Are individual patient records identifiable?", "answer": "No. All patient identifiers have been replaced with cryptographic hashes. The dataset cannot be linked back to individual patients without access to the original key, which is held securely by VGR's data protection office." },
+      { "question": "Can this data be linked with other registries?", "answer": "Linkage is possible through a formal application to VGR's data access committee. A trusted third party performs the linkage using encrypted identifiers." }
+    ]
   },
   {
     "id": "ds-002",
@@ -35,7 +60,34 @@
     "geographicCoverage": "National (Sweden)",
     "fairScore": { "findable": 5, "accessible": 4, "interoperable": 4, "reusable": 4, "total": 17 },
     "createdAt": "2025-04-22",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Genomics/Bioinformatics", "Clinical/Journal"],
+    "fileFormats": ["VCF", "BAM/CRAM", "CSV"],
+    "sensitivityLevel": "Special Category",
+    "dataSize": "850 GB",
+    "updateFrequency": "Annual",
+    "methodology": "Whole-genome sequencing performed on Illumina NovaSeq 6000 at 30x average coverage. Variants called using GATK HaplotypeCaller following best-practices pipeline (BWA-MEM2 alignment, BQSR, VQSR). Clinical phenotypes captured using Human Phenotype Ontology (HPO) terms by clinical geneticists. Pathogenicity assessed using ACMG/AMP guidelines.",
+    "limitations": "Coverage variability exists between earlier (2017-2019) and later samples due to platform upgrades. Approximately 8% of samples have mean coverage below 25x. Phenotype data completeness varies by recruiting center, with some centers providing more granular HPO annotations than others.",
+    "cohort": {
+      "ageRange": "0-65",
+      "sexDistribution": { "male": 45, "female": 55 },
+      "geographicArea": "National (Sweden)",
+      "sampleSize": 1200,
+      "description": "Patients diagnosed with rare hereditary diseases, recruited through clinical genetics centers across Sweden. Includes linked phenotype data using HPO terms. Major disease groups: neurological (32%), metabolic (24%), skeletal (18%), immunological (14%), other (12%)."
+    },
+    "useCases": [
+      { "title": "Rare Variant Discovery", "description": "Identify novel pathogenic variants in known disease genes or discover new gene-disease associations through cohort-level analysis." },
+      { "title": "Phenotype-Genotype Correlation", "description": "Study correlations between clinical phenotype severity and specific variant types across the rare disease spectrum." }
+    ],
+    "publications": [
+      { "title": "Diagnostic Yield of Whole-Genome Sequencing in Swedish Rare Disease Patients", "authors": "Eriksson A, Lindqvist R, Nilsson P et al.", "journal": "European Journal of Human Genetics", "year": 2023, "doi": "10.1038/s41431-023-01234-5", "url": "https://doi.org/10.1038/s41431-023-01234-5" },
+      { "title": "Novel Variants in Neurological Rare Diseases: A Swedish WGS Cohort Study", "authors": "Lindqvist R, Eriksson A, Berg J", "journal": "Genetics in Medicine", "year": 2024, "doi": "10.1016/j.gim.2024.100987", "url": "https://doi.org/10.1016/j.gim.2024.100987" }
+    ],
+    "faq": [
+      { "question": "What genome build is used?", "answer": "All data is aligned to GRCh38 (hg38). Variant coordinates are reported in GRCh38." },
+      { "question": "Is trio sequencing included?", "answer": "Approximately 40% of cases include parental samples (trios). These are flagged in the metadata but stored as individual samples." },
+      { "question": "How is data accessed?", "answer": "Data is only accessible within a Glass Sandbox environment at Karolinska. No data download is permitted. Researchers bring their analysis scripts to the secure environment." }
+    ]
   },
   {
     "id": "ds-003",
@@ -54,7 +106,32 @@
     "geographicCoverage": "Multi-site (Sweden, UK, Germany)",
     "fairScore": { "findable": 3, "accessible": 2, "interoperable": 3, "reusable": 2, "total": 10 },
     "createdAt": "2025-08-10",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Clinical/Journal"],
+    "fileFormats": ["CSV", "JSON", "PDF"],
+    "sensitivityLevel": "Aggregated",
+    "dataSize": "340 MB",
+    "updateFrequency": "One-time",
+    "methodology": "Multi-center, double-blind, randomized controlled trial conducted across 45 sites in Sweden, UK, and Germany. Patients randomized 1:1 to novel anticoagulant vs standard of care. Primary endpoint: composite of stroke, systemic embolism, and cardiovascular death. Data monitored by independent DSMB. Statistical analysis per pre-registered SAP.",
+    "limitations": "Aggregated-level data only — individual patient data requires separate agreement. Trial population may not fully represent real-world patient demographics due to strict inclusion/exclusion criteria. Follow-up limited to 3.5 years.",
+    "cohort": {
+      "ageRange": "45-85",
+      "sexDistribution": { "male": 58, "female": 42 },
+      "geographicArea": "Sweden, UK, Germany",
+      "sampleSize": 18500,
+      "description": "Patients with non-valvular atrial fibrillation at moderate-to-high stroke risk (CHA2DS2-VASc score >= 2). Exclusion criteria included severe renal impairment, active bleeding, and recent surgery."
+    },
+    "useCases": [
+      { "title": "Comparative Effectiveness Research", "description": "Compare trial outcomes against real-world evidence from national registries to assess generalizability." },
+      { "title": "Subgroup Meta-Analysis", "description": "Combine with other trial datasets for subgroup analyses (e.g., age-stratified or sex-stratified outcomes)." }
+    ],
+    "publications": [
+      { "title": "Efficacy and Safety of Novel Anticoagulant in Non-Valvular AF: Phase III Results", "authors": "AstraZeneca Clinical Study Team", "journal": "The Lancet", "year": 2023, "doi": "10.1016/S0140-6736(23)01234-5", "url": "https://doi.org/10.1016/S0140-6736(23)01234-5" }
+    ],
+    "faq": [
+      { "question": "Is individual patient data available?", "answer": "Individual patient-level data may be available through a separate data sharing agreement with AstraZeneca. Contact dataaccess@astrazeneca.com for details." },
+      { "question": "What analysis tools are supported?", "answer": "Data is provided in CSV and JSON formats compatible with R, Python, SAS, and STATA." }
+    ]
   },
   {
     "id": "ds-004",
@@ -73,7 +150,36 @@
     "geographicCoverage": "Region Stockholm",
     "fairScore": { "findable": 5, "accessible": 4, "interoperable": 5, "reusable": 4, "total": 18 },
     "createdAt": "2025-03-01",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Clinical/Journal", "Physiological"],
+    "fileFormats": ["CSV", "JSON", "FHIR/JSON", "Parquet"],
+    "sensitivityLevel": "Pseudonymized",
+    "dataSize": "2.8 GB",
+    "updateFrequency": "One-time",
+    "methodology": "Cases identified through mandatory reporting to the Swedish Public Health Agency (Folkhälsomyndigheten). PCR-confirmed cases linked with vaccination registry, hospital admission data, and ICU registry. Variant classification based on whole-genome sequencing of representative samples per surveillance protocol. Municipality-level geographic coding applied.",
+    "limitations": "Testing policies changed significantly across pandemic waves, affecting case ascertainment. Rapid antigen test results are underrepresented (not mandatory reporting). Vaccination data may be incomplete for individuals vaccinated abroad. Variant classification covers approximately 15% of all confirmed cases.",
+    "cohort": {
+      "ageRange": "0-105",
+      "sexDistribution": { "male": 49, "female": 51 },
+      "geographicArea": "Region Stockholm",
+      "sampleSize": 890000,
+      "description": "All confirmed COVID-19 cases reported through the mandatory surveillance system in Region Stockholm across four pandemic waves (2020-2023). Population-level coverage with linked vaccination and hospitalization data."
+    },
+    "useCases": [
+      { "title": "Vaccination Effectiveness Studies", "description": "Evaluate vaccine effectiveness against infection, hospitalization, and ICU admission across different variants and age groups." },
+      { "title": "Variant Epidemiology", "description": "Analyze the spread and impact of different SARS-CoV-2 variants on disease severity and transmission dynamics." },
+      { "title": "Hospitalization Prediction Models", "description": "Develop machine learning models to predict hospitalization risk based on demographic factors, vaccination status, and variant type." }
+    ],
+    "publications": [
+      { "title": "COVID-19 Surveillance in Stockholm: Epidemiological Patterns Across Four Waves", "authors": "Bergman A, Lindgren S, Ohlsson T", "journal": "Eurosurveillance", "year": 2023, "doi": "10.2807/1560-7917.ES.2023.28.1.2200987", "url": "https://doi.org/10.2807/1560-7917.ES.2023.28.1.2200987" },
+      { "title": "Vaccine Effectiveness Against Omicron Hospitalization in Stockholm", "authors": "Lindgren S, Bergman A, Falk K et al.", "journal": "The Lancet Regional Health - Europe", "year": 2023, "doi": "10.1016/j.lanepe.2023.100654", "url": "https://doi.org/10.1016/j.lanepe.2023.100654" },
+      { "title": "Impact of Variant Emergence on ICU Admissions: A Registry-Based Analysis", "authors": "Ohlsson T, Bergman A", "journal": "Intensive Care Medicine", "year": 2024, "doi": "10.1007/s00134-024-07123-4", "url": "https://doi.org/10.1007/s00134-024-07123-4" }
+    ],
+    "faq": [
+      { "question": "How are pandemic waves defined?", "answer": "Wave 1: Feb-Aug 2020 (wild type), Wave 2: Sep 2020-May 2021 (Alpha), Wave 3: Jun-Dec 2021 (Delta), Wave 4: Jan-Sep 2023 (Omicron and subvariants)." },
+      { "question": "Is reinfection data included?", "answer": "Yes, individuals can appear multiple times if they had confirmed reinfections. Each episode is a separate record linked by a pseudonymized patient identifier." },
+      { "question": "Can the data be exported?", "answer": "The dataset is available under CC BY 4.0. Aggregated exports are freely available. Record-level data requires a formal access application." }
+    ]
   },
   {
     "id": "ds-005",
@@ -92,7 +198,32 @@
     "geographicCoverage": "Vastra Gotalandsregionen",
     "fairScore": { "findable": 4, "accessible": 4, "interoperable": 4, "reusable": 3, "total": 15 },
     "createdAt": "2025-05-18",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Clinical/Journal", "Physiological"],
+    "fileFormats": ["CSV", "Excel"],
+    "sensitivityLevel": "Pseudonymized",
+    "dataSize": "180 MB",
+    "updateFrequency": "Annual",
+    "methodology": "Prospective registration of all acute stroke admissions at Sahlgrenska University Hospital, part of the Swedish National Stroke Registry (Riksstroke). NIHSS scoring performed by certified stroke nurses at admission and discharge. 90-day follow-up via structured telephone interview. Stroke type confirmed by neuroimaging (CT/MRI) reviewed by neuroradiologist.",
+    "limitations": "Registry covers only Sahlgrenska University Hospital, not the full VGR region. Patients who died before hospital admission are not captured. 90-day follow-up completion rate is approximately 88%. NIHSS at admission may be missing for patients who arrived outside regular hours before 2018.",
+    "cohort": {
+      "ageRange": "18-102",
+      "sexDistribution": { "male": 53, "female": 47 },
+      "geographicArea": "Vastra Gotalandsregionen",
+      "sampleSize": 34200,
+      "description": "All acute stroke admissions (ischemic 82%, hemorrhagic 15%, other 3%) at Sahlgrenska University Hospital 2015-2024. Median age 74 years. Includes treatment details, neurological severity scores, and functional outcomes at 90 days."
+    },
+    "useCases": [
+      { "title": "Treatment Quality Benchmarking", "description": "Compare door-to-needle times and reperfusion rates against national and international benchmarks." },
+      { "title": "Outcome Prediction Modeling", "description": "Develop predictive models for 90-day functional outcome (mRS) based on admission characteristics and treatment variables." }
+    ],
+    "publications": [
+      { "title": "Ten Years of Stroke Care at Sahlgrenska: Trends in Treatment and Outcomes", "authors": "Nordberg M, Eriksson C, Petersson A", "journal": "Stroke", "year": 2025, "doi": "10.1161/STROKEAHA.125.045678", "url": "https://doi.org/10.1161/STROKEAHA.125.045678" }
+    ],
+    "faq": [
+      { "question": "What stroke types are included?", "answer": "Ischemic stroke (82%), intracerebral hemorrhage (15%), and subarachnoid hemorrhage/other (3%). TIA cases are not included." },
+      { "question": "Is this connected to Riksstroke?", "answer": "Yes, this is the Sahlgrenska subset of the Swedish National Stroke Registry (Riksstroke) with additional local variables not captured nationally." }
+    ]
   },
   {
     "id": "ds-006",
@@ -111,7 +242,32 @@
     "geographicCoverage": "National (Sweden)",
     "fairScore": { "findable": 4, "accessible": 3, "interoperable": 2, "reusable": 3, "total": 12 },
     "createdAt": "2025-07-02",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Imaging", "Clinical/Journal"],
+    "fileFormats": ["DICOM", "CSV", "JSON"],
+    "sensitivityLevel": "Anonymized",
+    "dataSize": "45 GB",
+    "updateFrequency": "One-time",
+    "methodology": "Chest X-ray images collected from five Swedish hospitals, de-identified using DICOM anonymization tools (removing patient name, ID, dates). Two board-certified radiologists independently annotated each image for 14 pathology classes. Disagreements resolved by a third senior radiologist. Bounding box annotations for localization tasks created using LabelImg tool.",
+    "limitations": "Dataset skewed toward PA (posteroanterior) views (85%). Lateral views underrepresented. Age distribution skewed toward elderly patients (median 65 years). Some pathology classes have fewer than 500 examples. Original DICOM metadata beyond demographics has been stripped for anonymization.",
+    "cohort": {
+      "ageRange": "18-97",
+      "sexDistribution": { "male": 55, "female": 45 },
+      "geographicArea": "National (Sweden)",
+      "sampleSize": 52000,
+      "description": "Chest X-ray images from patients across five Swedish hospitals. 14 pathology classes annotated including cardiomegaly, pneumonia, effusion, atelectasis, pneumothorax, consolidation, edema, emphysema, fibrosis, hernia, mass, nodule, pleural thickening, and no finding."
+    },
+    "useCases": [
+      { "title": "Automated Screening Algorithm Development", "description": "Train deep learning models for automated chest X-ray screening in emergency and primary care settings." },
+      { "title": "Multi-Label Classification Research", "description": "Develop and benchmark multi-label classification approaches for overlapping chest pathologies." }
+    ],
+    "publications": [
+      { "title": "A Swedish Annotated Chest X-ray Dataset for AI Model Development", "authors": "Lindblom T, Hasselgren G, Ahlstrom H", "journal": "Scientific Data", "year": 2023, "doi": "10.1038/s41597-023-02345-6", "url": "https://doi.org/10.1038/s41597-023-02345-6" }
+    ],
+    "faq": [
+      { "question": "Are the images in DICOM or standard image format?", "answer": "Both. Original DICOM files are preserved for full metadata access. PNG exports at 1024x1024 resolution are also available with annotation CSV files for easier ML pipeline integration." },
+      { "question": "Can models trained on this data be deployed commercially?", "answer": "The CC BY-NC 4.0 license restricts commercial use. Contact the data holder to discuss commercial licensing options." }
+    ]
   },
   {
     "id": "ds-007",
@@ -130,7 +286,32 @@
     "geographicCoverage": "Vastra Gotalandsregionen",
     "fairScore": { "findable": 3, "accessible": 2, "interoperable": 3, "reusable": 2, "total": 10 },
     "createdAt": "2025-09-12",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Biobank/Samples", "Clinical/Journal", "Physiological"],
+    "fileFormats": ["CSV", "HDF5", "Excel"],
+    "sensitivityLevel": "Special Category",
+    "dataSize": "3.2 GB",
+    "updateFrequency": "Annual",
+    "methodology": "Plasma samples collected from participants in the Gothenburg Population Study at baseline and 5-year follow-up. Untargeted metabolomics performed using LC-MS/MS (Thermo Q Exactive) with quality control samples interspersed. Data processed using MZmine and normalized using probabilistic quotient normalization. Lifestyle data from validated questionnaires. Follow-up diagnoses from the Swedish National Patient Registry.",
+    "limitations": "Metabolomics measurements have inherent batch effects despite normalization efforts. Missing lifestyle data for approximately 12% of participants. Follow-up diagnoses limited to hospital-based care (outpatient and inpatient) — primary care diagnoses not linked. Biobank sample degradation may affect some metabolite measurements in earliest samples.",
+    "cohort": {
+      "ageRange": "30-75",
+      "sexDistribution": { "male": 46, "female": 54 },
+      "geographicArea": "Gothenburg metropolitan area",
+      "sampleSize": 8700,
+      "description": "Population-based cohort from the Gothenburg Population Study. Participants recruited randomly from the population registry. Includes baseline metabolomics, lifestyle questionnaire data (diet, physical activity, smoking, alcohol), BMI, blood pressure, and 10-year follow-up health outcomes including cardiovascular events, diabetes onset, and cancer diagnoses."
+    },
+    "useCases": [
+      { "title": "Metabolomic Biomarker Discovery", "description": "Identify metabolite signatures predictive of cardiovascular disease, type 2 diabetes, or cancer development." },
+      { "title": "Lifestyle-Metabolism Interaction Studies", "description": "Investigate how lifestyle factors (diet, exercise, smoking) modify metabolomic profiles and disease risk." }
+    ],
+    "publications": [
+      { "title": "Plasma Metabolomics and 10-Year Cardiovascular Risk in a Swedish Population Cohort", "authors": "Olsson B, Karlsson J, Svensson E", "journal": "Metabolomics", "year": 2024, "doi": "10.1007/s11306-024-02156-7", "url": "https://doi.org/10.1007/s11306-024-02156-7" }
+    ],
+    "faq": [
+      { "question": "What metabolomics platform was used?", "answer": "Untargeted LC-MS/MS using a Thermo Q Exactive Plus. Both positive and negative ionization modes were used, covering approximately 2,500 annotated metabolites." },
+      { "question": "Are the biobank samples still available?", "answer": "Yes, remaining aliquots may be available for additional analyses. Contact the Gothenburg Biobank for sample availability and access procedures." }
+    ]
   },
   {
     "id": "ds-008",
@@ -149,7 +330,28 @@
     "geographicCoverage": "National (Sweden)",
     "fairScore": { "findable": 3, "accessible": 2, "interoperable": 2, "reusable": 1, "total": 8 },
     "createdAt": "2025-10-05",
-    "status": "draft"
+    "status": "draft",
+    "dataTypes": ["Physiological", "Clinical/Journal"],
+    "fileFormats": ["Parquet", "CSV"],
+    "sensitivityLevel": "Pseudonymized",
+    "dataSize": "28 GB",
+    "updateFrequency": "Ongoing",
+    "methodology": "Vital signs extracted from ICU bedside monitors (Philips IntelliVue) at 1-minute resolution. Data quality pipeline includes artifact removal, interpolation of short gaps (<5 min), and outlier flagging. Formatted as time-series partitioned by ICU stay. Designed for federated learning with standardized feature schema across participating sites.",
+    "limitations": "Data preparation is ongoing. Current version covers 3 of 5 planned ICU sites. Monitor brand differences introduce measurement variability. Artifact removal algorithm may inadvertently remove valid extreme values. No medication data linked yet.",
+    "cohort": {
+      "ageRange": "18-95",
+      "sexDistribution": { "male": 57, "female": 43 },
+      "geographicArea": "National (Sweden)",
+      "sampleSize": 12500,
+      "description": "Adult ICU patients (medical, surgical, and cardiac ICU) from three Swedish university hospitals. Average ICU stay 4.2 days. Major admission categories: post-surgical (35%), sepsis (22%), respiratory failure (18%), cardiac (15%), trauma (10%)."
+    },
+    "useCases": [
+      { "title": "Early Warning Score Development", "description": "Train federated ML models for early detection of clinical deterioration using multi-site vital sign patterns." }
+    ],
+    "publications": [],
+    "faq": [
+      { "question": "When will all five sites be included?", "answer": "The remaining two sites are expected to complete data preparation by Q2 2026. Draft status reflects the ongoing integration." }
+    ]
   },
   {
     "id": "ds-009",
@@ -168,7 +370,32 @@
     "geographicCoverage": "National (Sweden)",
     "fairScore": { "findable": 4, "accessible": 3, "interoperable": 4, "reusable": 3, "total": 14 },
     "createdAt": "2025-07-28",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Clinical/Journal"],
+    "fileFormats": ["CSV", "JSON", "XML"],
+    "sensitivityLevel": "Anonymized",
+    "dataSize": "520 MB",
+    "updateFrequency": "Quarterly",
+    "methodology": "Adverse drug reaction reports collected through the Swedish spontaneous reporting system (SWEDIS) and supplemented with company-held safety data. Reports coded using MedDRA (version 26.1) for adverse events and WHO ATC classification for suspect drugs. Duplicate detection performed using probabilistic record matching. Seriousness assessed per ICH E2B criteria.",
+    "limitations": "Spontaneous reporting is subject to significant underreporting bias — estimated capture rate 5-10% of actual ADRs. Reporter qualification varies (healthcare professionals vs consumers). Causality not assessed in raw reports. Temporal trends influenced by media attention and regulatory actions.",
+    "cohort": {
+      "ageRange": "0-99",
+      "sexDistribution": { "male": 42, "female": 58 },
+      "geographicArea": "National (Sweden)",
+      "sampleSize": 162000,
+      "description": "All spontaneous adverse drug reaction reports from Sweden (2010-2024). Reporter types: physicians (45%), pharmacists (20%), nurses (15%), consumers (20%). Drug classes represented across all ATC groups with highest volume in cardiovascular, oncology, and CNS medications."
+    },
+    "useCases": [
+      { "title": "Statistical Signal Detection", "description": "Apply disproportionality analysis methods (PRR, ROR, BCPNN) to identify potential safety signals for marketed drugs." },
+      { "title": "Time-to-Onset Analysis", "description": "Characterize temporal patterns of adverse drug reactions to support causality assessment." }
+    ],
+    "publications": [
+      { "title": "Automated Signal Detection in Swedish Pharmacovigilance Data: A Comparative Analysis", "authors": "Hallberg P, Szilcz M, Wadelius M", "journal": "Drug Safety", "year": 2024, "doi": "10.1007/s40264-024-01389-2", "url": "https://doi.org/10.1007/s40264-024-01389-2" }
+    ],
+    "faq": [
+      { "question": "How current is the data?", "answer": "The dataset is updated quarterly with new reports. The latest refresh includes reports through March 2024." },
+      { "question": "Is this the same as EudraVigilance data?", "answer": "No. This dataset is specific to Swedish reports. Some overlap exists with EudraVigilance for Swedish-origin reports, but this dataset includes additional detail and consumer reports not always forwarded to EU databases." }
+    ]
   },
   {
     "id": "ds-010",
@@ -187,7 +414,32 @@
     "geographicCoverage": "Vastra Gotalandsregionen",
     "fairScore": { "findable": 4, "accessible": 3, "interoperable": 3, "reusable": 4, "total": 14 },
     "createdAt": "2025-11-20",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Imaging", "Clinical/Journal", "Physiological"],
+    "fileFormats": ["DICOM", "CSV"],
+    "sensitivityLevel": "Pseudonymized",
+    "dataSize": "120 GB",
+    "updateFrequency": "Annual",
+    "methodology": "Retinal OCT scans acquired using Heidelberg Spectralis HRA+OCT devices during routine diabetic eye screening. Each scan independently graded by two board-certified ophthalmologists using ETDRS severity scale. Cohen's kappa for inter-rater agreement: 0.82. Discordant grades resolved by a senior retinal specialist. Linked with HbA1c values from clinical chemistry database.",
+    "limitations": "Only patients attending screening at Sahlgrenska are included — patients managed elsewhere or non-attendees not captured. OCT image quality varies; approximately 5% of scans excluded due to poor quality. HbA1c values may be up to 6 months before or after the scan date.",
+    "cohort": {
+      "ageRange": "25-88",
+      "sexDistribution": { "male": 54, "female": 46 },
+      "geographicArea": "Vastra Gotalandsregionen",
+      "sampleSize": 7400,
+      "description": "Diabetic patients (Type 1: 35%, Type 2: 65%) attending routine retinal screening at Sahlgrenska University Hospital. Multiple scans per patient (average 2.0 scans). ETDRS grades: No retinopathy (45%), mild NPDR (25%), moderate NPDR (15%), severe NPDR (10%), PDR (5%)."
+    },
+    "useCases": [
+      { "title": "Automated Retinopathy Screening", "description": "Develop AI models for automated diabetic retinopathy detection and grading from OCT scans to support nationwide screening programs." },
+      { "title": "Disease Progression Analysis", "description": "Study retinopathy progression patterns using longitudinal OCT data linked with metabolic control markers." }
+    ],
+    "publications": [
+      { "title": "Deep Learning for Diabetic Retinopathy Grading from OCT: A Swedish Validation Study", "authors": "Holmberg J, Andersson K, Malmqvist L", "journal": "Ophthalmology", "year": 2025, "doi": "10.1016/j.ophtha.2025.01.234", "url": "https://doi.org/10.1016/j.ophtha.2025.01.234" }
+    ],
+    "faq": [
+      { "question": "What OCT device was used?", "answer": "All scans acquired on Heidelberg Spectralis HRA+OCT. Volume scans centered on the macula with 49 B-scans covering a 6x6mm area." },
+      { "question": "Is color fundus photography also available?", "answer": "Not in this dataset. Color fundus images may be available as a separate dataset — contact the data holder for details." }
+    ]
   },
   {
     "id": "ds-011",
@@ -206,7 +458,35 @@
     "geographicCoverage": "National (Sweden)",
     "fairScore": { "findable": 5, "accessible": 5, "interoperable": 5, "reusable": 5, "total": 20 },
     "createdAt": "2025-02-14",
-    "status": "published"
+    "status": "published",
+    "dataTypes": ["Clinical/Journal"],
+    "fileFormats": ["CSV", "Parquet", "JSON"],
+    "sensitivityLevel": "Pseudonymized",
+    "dataSize": "4.5 GB",
+    "updateFrequency": "Annual",
+    "methodology": "Data compiled from the three national cancer screening programs: cervical (organized since 1960s), breast (since 1986), and colorectal (national rollout 2022). Invitation and participation data from regional screening coordination. Test results from certified laboratories. Follow-up diagnostics and staging from the Swedish Cancer Registry. Cross-linked using pseudonymized personal identifiers.",
+    "limitations": "Colorectal screening program has limited historical data (national since 2022, pilot regions from 2014). Regional variation in screening invitation intervals. Opportunistic screening outside organized programs is not captured. Some regions transitioned from cytology to HPV-based cervical screening during the study period.",
+    "cohort": {
+      "ageRange": "23-74",
+      "sexDistribution": { "male": 35, "female": 65 },
+      "geographicArea": "National (Sweden)",
+      "sampleSize": 1450000,
+      "description": "All individuals invited to organized cancer screening programs in Sweden. Cervical screening: women 23-64. Breast screening (mammography): women 40-74. Colorectal screening (FIT test): men and women 60-74. Overall participation rate approximately 72%."
+    },
+    "useCases": [
+      { "title": "Screening Program Evaluation", "description": "Evaluate participation rates, detection rates, and interval cancer rates across regions to optimize screening program effectiveness." },
+      { "title": "Health Equity Analysis", "description": "Analyze screening participation disparities across sociodemographic groups and geographic regions." },
+      { "title": "Cost-Effectiveness Modeling", "description": "Model the cost-effectiveness of different screening intervals and modalities using real-world outcome data." }
+    ],
+    "publications": [
+      { "title": "National Cancer Screening in Sweden: Participation, Detection Rates and Stage Distribution 2014-2024", "authors": "Wallin E, Dillner J, Törnberg S et al.", "journal": "European Journal of Cancer Prevention", "year": 2025, "doi": "10.1097/CEJ.0000000000000876", "url": "https://doi.org/10.1097/CEJ.0000000000000876" },
+      { "title": "Colorectal Cancer Screening Rollout in Sweden: Early Implementation Results", "authors": "Törnberg S, Wallin E", "journal": "Gut", "year": 2024, "doi": "10.1136/gutjnl-2024-332456", "url": "https://doi.org/10.1136/gutjnl-2024-332456" }
+    ],
+    "faq": [
+      { "question": "Which cancer types are covered?", "answer": "Cervical cancer (HPV/cytology screening), breast cancer (mammography), and colorectal cancer (fecal immunochemical test, FIT)." },
+      { "question": "Is individual-level data available?", "answer": "Yes, under formal access agreement. The CC BY 4.0 license applies to aggregated statistics. Individual-level pseudonymized data requires ethics approval and a Data Use Agreement." },
+      { "question": "Can this be linked with the Cancer Quality Registries?", "answer": "Yes, linkage with INCA (Swedish Cancer Quality Registries) is possible through application to the registry holder." }
+    ]
   },
   {
     "id": "ds-012",
@@ -225,6 +505,27 @@
     "geographicCoverage": "Region Stockholm",
     "fairScore": { "findable": 2, "accessible": 2, "interoperable": 1, "reusable": 1, "total": 6 },
     "createdAt": "2025-12-01",
-    "status": "draft"
+    "status": "draft",
+    "dataTypes": ["Genomics/Bioinformatics", "Biobank/Samples", "Clinical/Journal"],
+    "fileFormats": ["CSV", "HDF5", "JSON"],
+    "sensitivityLevel": "Special Category",
+    "dataSize": "15 GB",
+    "updateFrequency": "Ongoing",
+    "methodology": "RNA-seq performed on whole blood using Illumina NovaSeq (poly-A enrichment, 50M reads/sample). Proteomics using TMT-labeled mass spectrometry (Thermo Exploris 480). Clinical metadata extracted from Karolinska EHR. Data harmonization to OMOP CDM is in progress. Quality control includes PCA-based outlier detection and batch correction using ComBat-seq.",
+    "limitations": "Pilot dataset with limited sample size (n=500). Data harmonization to OMOP is ongoing — current version may have inconsistencies. Proteomics coverage limited to ~3,000 proteins. Missing clinical data for approximately 15% of samples. No longitudinal follow-up yet (planned for Phase 2).",
+    "cohort": {
+      "ageRange": "22-78",
+      "sexDistribution": { "male": 25, "female": 75 },
+      "geographicArea": "Region Stockholm",
+      "sampleSize": 500,
+      "description": "Patients with rheumatoid arthritis (n=300, 60%) and systemic lupus erythematosus (n=200, 40%) recruited from Karolinska University Hospital rheumatology clinic. Includes matched multi-omics data (transcriptomics + proteomics) and disease activity scores (DAS28 for RA, SLEDAI for SLE)."
+    },
+    "useCases": [
+      { "title": "Multi-Omics Disease Subtyping", "description": "Identify molecular subtypes of RA and SLE using integrated transcriptomic and proteomic signatures." }
+    ],
+    "publications": [],
+    "faq": [
+      { "question": "When will the full dataset be available?", "answer": "The pilot phase is expected to complete data harmonization by Q3 2026. A larger Phase 2 dataset (n=2000) is planned for 2027." }
+    ]
   }
 ]

--- a/src/pages/DatasetDetail.jsx
+++ b/src/pages/DatasetDetail.jsx
@@ -1,8 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useData } from '../context/DataContext';
 import { useAuth } from '../context/AuthContext';
-import { getFairLabel, getFairColor } from '../utils/fairScore';
+import DatasetHeader from '../components/dataset-detail/DatasetHeader';
+import DatasetSidebar from '../components/dataset-detail/DatasetSidebar';
+import OverviewTab from '../components/dataset-detail/OverviewTab';
+import DetailsTab from '../components/dataset-detail/DetailsTab';
+import DictionaryTab from '../components/dataset-detail/DictionaryTab';
+import SampleTab from '../components/dataset-detail/SampleTab';
+import AccessTab from '../components/dataset-detail/AccessTab';
+import UseCasesTab from '../components/dataset-detail/UseCasesTab';
+import PublicationsTab from '../components/dataset-detail/PublicationsTab';
+import FaqTab from '../components/dataset-detail/FaqTab';
 
 const ACCESS_MODEL_INFO = {
   a2d: {
@@ -13,7 +22,7 @@ const ACCESS_MODEL_INFO = {
   'data-behind-glass': {
     label: 'Data Behind Glass',
     description:
-      'Access and explore the data interactively within a monitored sandbox environment. Results are reviewed before export.',
+      'Access and explore the data interactively within a monitored Glass Sandbox environment. Results are reviewed before export.',
   },
   'metadata-light': {
     label: 'Metadata Light',
@@ -22,48 +31,69 @@ const ACCESS_MODEL_INFO = {
   },
 };
 
-const ACCESS_MODEL_STYLES = {
-  'a2d': { label: 'Algorithm to Data (A2D)', short: 'A2D', bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200', borderLeft: 'border-l-green-400' },
-  'data-behind-glass': { label: 'Data Behind Glass', short: 'Data Behind Glass', bg: 'bg-teal-100', text: 'text-teal-800', border: 'border-teal-300', borderLeft: 'border-l-teal-400' },
-  'metadata-light': { label: 'Metadata Light', short: 'Metadata Light', bg: 'bg-teal-50', text: 'text-teal-600', border: 'border-teal-200', borderLeft: 'border-l-teal-300' },
-};
-
-const FAIR_DIMENSIONS = [
-  { key: 'findable', label: 'Findable', color: 'bg-teal-500' },
-  { key: 'accessible', label: 'Accessible', color: 'bg-teal-400' },
-  { key: 'interoperable', label: 'Interoperable', color: 'bg-teal-600' },
-  { key: 'reusable', label: 'Reusable', color: 'bg-teal-800' },
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'details', label: 'Details' },
+  { id: 'dictionary', label: 'Dictionary' },
+  { id: 'sample', label: 'Sample' },
+  { id: 'access', label: 'Access' },
+  { id: 'use-cases', label: 'Use Cases' },
+  { id: 'publications', label: 'Publications' },
+  { id: 'faq', label: 'FAQ' },
 ];
 
-function formatCategory(cat) {
-  return cat
-    .split('-')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
+/* ===== Request Access Modal — 3-Step Wizard ===== */
+const RESEARCH_TYPES = [
+  'Clinical Study',
+  'Epidemiology',
+  'AI/ML Development',
+  'Registry Study',
+  'Quality Improvement',
+  'Other',
+];
+
+const INTENDED_USES = [
+  'Statistical Analysis',
+  'Data Linking',
+  'Training ML Model',
+  'Visualization',
+  'Quality Improvement',
+  'Other',
+];
+
+const STEP_LABELS = ['Research Context', 'Data Use', 'Documentation & Review'];
+
+function formatFileSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function formatNumber(num) {
-  return num.toLocaleString();
-}
-
-function formatDate(dateStr) {
-  return new Date(dateStr).toLocaleDateString('en-SE', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-/* ===== Request Access Modal ===== */
 function RequestAccessModal({ dataset, onClose, onSubmit }) {
-  const [accessModel, setAccessModel] = useState(
-    dataset.accessModels[0] || ''
-  );
+  const [step, setStep] = useState(1);
+  const [stepErrors, setStepErrors] = useState({});
+
+  // Step 1 — Research Context
+  const [accessModel, setAccessModel] = useState(dataset.accessModels[0] || '');
+  const [researchType, setResearchType] = useState('');
+  const [organization, setOrganization] = useState('');
+  const [ethicsApproval, setEthicsApproval] = useState('');
+  const [ethicsDnr, setEthicsDnr] = useState('');
+  const [timePeriodFrom, setTimePeriodFrom] = useState('');
+  const [timePeriodTo, setTimePeriodTo] = useState('');
+
+  // Step 2 — Data Use
+  const [intendedUse, setIntendedUse] = useState([]);
   const [purpose, setPurpose] = useState('');
+
+  // Step 3 — Documentation & Review
+  const [uploadedFiles, setUploadedFiles] = useState([]);
+  const fileInputRef = useRef(null);
+
+  // Submission state
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  // Close on Escape key
   useEffect(() => {
     function handleEscape(e) {
       if (e.key === 'Escape') onClose();
@@ -72,55 +102,98 @@ function RequestAccessModal({ dataset, onClose, onSubmit }) {
     return () => document.removeEventListener('keydown', handleEscape);
   }, [onClose]);
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!accessModel || !purpose.trim()) return;
+  const validateStep = (s) => {
+    const errors = {};
+    if (s === 1) {
+      if (!accessModel) errors.accessModel = 'Access model is required';
+      if (!researchType) errors.researchType = 'Research type is required';
+    } else if (s === 2) {
+      if (intendedUse.length === 0) errors.intendedUse = 'Select at least one intended use';
+    }
+    // Step 3 has no required fields
+    return errors;
+  };
+
+  const handleNext = () => {
+    const errors = validateStep(step);
+    if (Object.keys(errors).length > 0) {
+      setStepErrors(errors);
+      return;
+    }
+    setStepErrors({});
+    setStep((s) => s + 1);
+  };
+
+  const handleBack = () => {
+    setStepErrors({});
+    setStep((s) => s - 1);
+  };
+
+  const toggleIntendedUse = (use) => {
+    setIntendedUse((prev) =>
+      prev.includes(use) ? prev.filter((u) => u !== use) : [...prev, use]
+    );
+    if (stepErrors.intendedUse) {
+      setStepErrors((prev) => {
+        const next = { ...prev };
+        delete next.intendedUse;
+        return next;
+      });
+    }
+  };
+
+  const handleFileSelect = (e) => {
+    const files = Array.from(e.target.files);
+    const newFiles = files.map((f) => ({ name: f.name, size: f.size, type: f.type }));
+    setUploadedFiles((prev) => [...prev, ...newFiles]);
+    // Reset input so the same file can be re-selected
+    e.target.value = '';
+  };
+
+  const removeFile = (index) => {
+    setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async () => {
     setSubmitting(true);
     try {
-      await onSubmit({ accessModel, purpose: purpose.trim() });
+      await onSubmit({
+        accessModel,
+        researchType,
+        organization: organization.trim(),
+        ethicsApproval,
+        ethicsDnr: ethicsApproval === 'yes' ? ethicsDnr.trim() : '',
+        timePeriod: { from: timePeriodFrom, to: timePeriodTo },
+        intendedUse,
+        purpose: purpose.trim(),
+        uploadedFiles,
+      });
       setSubmitted(true);
     } finally {
       setSubmitting(false);
     }
   };
 
+  const inputClass =
+    'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 focus:outline-none';
+
+  /* ----- Success screen ----- */
   if (submitted) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div
-          className="fixed inset-0 bg-black/40 backdrop-blur-sm"
-          onClick={onClose}
-        />
+        <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
         <div className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
           <div className="text-center">
             <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-teal-100">
-              <svg
-                className="h-7 w-7 text-teal-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={2}
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="m4.5 12.75 6 6 9-13.5"
-                />
+              <svg className="h-7 w-7 text-teal-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
               </svg>
             </div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-1">
-              Request Submitted
-            </h3>
+            <h3 className="text-lg font-semibold text-gray-900 mb-1">Request Submitted</h3>
             <p className="text-sm text-gray-600 mb-6">
-              Your access request for{' '}
-              <span className="font-medium">{dataset.title}</span> has been
-              submitted successfully. The data holder will review your request.
+              Your access request for <span className="font-medium">{dataset.title}</span> has been submitted successfully. The data holder will review your request.
             </p>
-            <button
-              onClick={onClose}
-              className="rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors"
-            >
+            <button onClick={onClose} className="rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors">
               Done
             </button>
           </div>
@@ -129,139 +202,403 @@ function RequestAccessModal({ dataset, onClose, onSubmit }) {
     );
   }
 
+  /* ----- Step indicator ----- */
+  const StepIndicator = () => (
+    <div className="flex items-center justify-between mb-6">
+      {STEP_LABELS.map((label, i) => {
+        const stepNum = i + 1;
+        const isActive = stepNum === step;
+        const isCompleted = stepNum < step;
+        return (
+          <div key={label} className="flex items-center flex-1 last:flex-initial">
+            <div className="flex flex-col items-center">
+              <div
+                className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-colors ${
+                  isCompleted
+                    ? 'bg-teal-600 text-white'
+                    : isActive
+                      ? 'bg-teal-600 text-white'
+                      : 'bg-gray-200 text-gray-500'
+                }`}
+              >
+                {isCompleted ? (
+                  <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                  </svg>
+                ) : (
+                  stepNum
+                )}
+              </div>
+              <span
+                className={`mt-1.5 text-xs font-medium whitespace-nowrap ${
+                  isActive || isCompleted ? 'text-teal-700' : 'text-gray-400'
+                }`}
+              >
+                {label}
+              </span>
+            </div>
+            {stepNum < STEP_LABELS.length && (
+              <div
+                className={`mx-3 mt-[-1rem] h-0.5 flex-1 ${
+                  isCompleted ? 'bg-teal-500' : 'bg-gray-200'
+                }`}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  /* ----- Step 1: Research Context ----- */
+  const renderStep1 = () => (
+    <div className="space-y-4">
+      {/* Access Model */}
+      <div>
+        <label htmlFor="req-access-model" className="block text-sm font-semibold text-gray-700 mb-1.5">
+          Access Model <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="req-access-model"
+          value={accessModel}
+          onChange={(e) => { setAccessModel(e.target.value); setStepErrors((p) => { const n = { ...p }; delete n.accessModel; return n; }); }}
+          className={`${inputClass} bg-white`}
+        >
+          <option value="">Select access model...</option>
+          {dataset.accessModels.map((model) => (
+            <option key={model} value={model}>{ACCESS_MODEL_INFO[model]?.label || model}</option>
+          ))}
+        </select>
+        {accessModel && ACCESS_MODEL_INFO[accessModel] && (
+          <p className="mt-1.5 text-xs text-gray-500">{ACCESS_MODEL_INFO[accessModel].description}</p>
+        )}
+        {stepErrors.accessModel && <p className="mt-1 text-xs text-red-600">{stepErrors.accessModel}</p>}
+      </div>
+
+      {/* Research Type */}
+      <div>
+        <label htmlFor="req-research-type" className="block text-sm font-semibold text-gray-700 mb-1.5">
+          Research Type <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="req-research-type"
+          value={researchType}
+          onChange={(e) => { setResearchType(e.target.value); setStepErrors((p) => { const n = { ...p }; delete n.researchType; return n; }); }}
+          className={`${inputClass} bg-white`}
+        >
+          <option value="">Select research type...</option>
+          {RESEARCH_TYPES.map((rt) => (
+            <option key={rt} value={rt}>{rt}</option>
+          ))}
+        </select>
+        {stepErrors.researchType && <p className="mt-1 text-xs text-red-600">{stepErrors.researchType}</p>}
+      </div>
+
+      {/* Organization */}
+      <div>
+        <label htmlFor="req-organization" className="block text-sm font-semibold text-gray-700 mb-1.5">Organization</label>
+        <input
+          id="req-organization"
+          type="text"
+          value={organization}
+          onChange={(e) => setOrganization(e.target.value)}
+          placeholder="e.g. University of Gothenburg"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Ethics Approval */}
+      <div>
+        <span className="block text-sm font-semibold text-gray-700 mb-2">Ethics Approval</span>
+        <div className="flex items-center gap-6">
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="radio"
+              name="ethics-approval"
+              value="yes"
+              checked={ethicsApproval === 'yes'}
+              onChange={() => setEthicsApproval('yes')}
+              className="h-4 w-4 text-teal-600 border-gray-300 focus:ring-teal-500"
+            />
+            Yes
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="radio"
+              name="ethics-approval"
+              value="no"
+              checked={ethicsApproval === 'no'}
+              onChange={() => { setEthicsApproval('no'); setEthicsDnr(''); }}
+              className="h-4 w-4 text-teal-600 border-gray-300 focus:ring-teal-500"
+            />
+            No
+          </label>
+        </div>
+        {ethicsApproval === 'yes' && (
+          <div className="mt-3">
+            <label htmlFor="req-ethics-dnr" className="block text-sm font-medium text-gray-600 mb-1">
+              Ethics Review Number (DNR)
+            </label>
+            <input
+              id="req-ethics-dnr"
+              type="text"
+              value={ethicsDnr}
+              onChange={(e) => setEthicsDnr(e.target.value)}
+              placeholder="e.g. 2024-01234-01"
+              className={inputClass}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Time Period */}
+      <div>
+        <span className="block text-sm font-semibold text-gray-700 mb-1.5">Time Period</span>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="req-time-from" className="block text-xs text-gray-500 mb-1">From</label>
+            <input
+              id="req-time-from"
+              type="date"
+              value={timePeriodFrom}
+              onChange={(e) => setTimePeriodFrom(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label htmlFor="req-time-to" className="block text-xs text-gray-500 mb-1">To</label>
+            <input
+              id="req-time-to"
+              type="date"
+              value={timePeriodTo}
+              onChange={(e) => setTimePeriodTo(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  /* ----- Step 2: Data Use ----- */
+  const renderStep2 = () => (
+    <div className="space-y-4">
+      {/* Intended Data Use */}
+      <div>
+        <span className="block text-sm font-semibold text-gray-700 mb-2">
+          Intended Data Use <span className="text-red-500">*</span>
+        </span>
+        <div className="grid grid-cols-2 gap-2">
+          {INTENDED_USES.map((use) => (
+            <label
+              key={use}
+              className={`flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-sm cursor-pointer transition-colors ${
+                intendedUse.includes(use)
+                  ? 'border-teal-500 bg-teal-50 text-teal-800'
+                  : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={intendedUse.includes(use)}
+                onChange={() => toggleIntendedUse(use)}
+                className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+              />
+              {use}
+            </label>
+          ))}
+        </div>
+        {stepErrors.intendedUse && <p className="mt-1 text-xs text-red-600">{stepErrors.intendedUse}</p>}
+      </div>
+
+      {/* Purpose Description */}
+      <div>
+        <label htmlFor="req-purpose" className="block text-sm font-semibold text-gray-700 mb-1.5">Purpose Description</label>
+        <textarea
+          id="req-purpose"
+          rows={4}
+          value={purpose}
+          onChange={(e) => setPurpose(e.target.value)}
+          placeholder="Provide additional details about your research purpose and how you intend to use this dataset..."
+          className={`${inputClass} resize-none placeholder:text-gray-400`}
+        />
+      </div>
+    </div>
+  );
+
+  /* ----- Step 3: Documentation & Review ----- */
+  const renderStep3 = () => (
+    <div className="space-y-5">
+      {/* File Upload */}
+      <div>
+        <span className="block text-sm font-semibold text-gray-700 mb-2">Supporting Documents</span>
+        <div
+          onClick={() => fileInputRef.current?.click()}
+          className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-6 cursor-pointer hover:border-teal-400 hover:bg-teal-50/30 transition-colors"
+        >
+          <svg className="h-8 w-8 text-gray-400 mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z" />
+          </svg>
+          <p className="text-sm font-medium text-gray-600">Click to upload files</p>
+          <p className="text-xs text-gray-400 mt-1">PDF, DOCX, DOC, TXT</p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept=".pdf,.docx,.doc,.txt"
+            onChange={handleFileSelect}
+            className="hidden"
+          />
+        </div>
+        {uploadedFiles.length > 0 && (
+          <ul className="mt-3 space-y-2">
+            {uploadedFiles.map((file, i) => (
+              <li key={`${file.name}-${i}`} className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  <svg className="h-4 w-4 flex-shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                  </svg>
+                  <span className="text-sm text-gray-700 truncate">{file.name}</span>
+                  <span className="text-xs text-gray-400 flex-shrink-0">{formatFileSize(file.size)}</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeFile(i)}
+                  className="ml-2 flex-shrink-0 rounded p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+                  aria-label={`Remove ${file.name}`}
+                >
+                  <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Review Summary */}
+      <div>
+        <span className="block text-sm font-semibold text-gray-700 mb-2">Review Summary</span>
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+            <div>
+              <dt className="text-xs font-medium text-gray-500">Access Model</dt>
+              <dd className="text-gray-800">{ACCESS_MODEL_INFO[accessModel]?.label || accessModel || '--'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500">Research Type</dt>
+              <dd className="text-gray-800">{researchType || '--'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500">Organization</dt>
+              <dd className="text-gray-800">{organization.trim() || '--'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500">Ethics Approval</dt>
+              <dd className="text-gray-800">
+                {ethicsApproval === 'yes' ? `Yes${ethicsDnr.trim() ? ` (${ethicsDnr.trim()})` : ''}` : ethicsApproval === 'no' ? 'No' : '--'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500">Time Period</dt>
+              <dd className="text-gray-800">
+                {timePeriodFrom || timePeriodTo
+                  ? `${timePeriodFrom || '...'} to ${timePeriodTo || '...'}`
+                  : '--'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500">Intended Use</dt>
+              <dd className="text-gray-800">{intendedUse.length > 0 ? intendedUse.join(', ') : '--'}</dd>
+            </div>
+            {purpose.trim() && (
+              <div className="col-span-2">
+                <dt className="text-xs font-medium text-gray-500">Purpose</dt>
+                <dd className="text-gray-800 whitespace-pre-line">{purpose.trim()}</dd>
+              </div>
+            )}
+            {uploadedFiles.length > 0 && (
+              <div className="col-span-2">
+                <dt className="text-xs font-medium text-gray-500">Uploaded Files</dt>
+                <dd className="text-gray-800">{uploadedFiles.map((f) => f.name).join(', ')}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div
-        className="fixed inset-0 bg-black/40 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      <div role="dialog" aria-modal="true" className="relative w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
-        <div className="flex items-center justify-between mb-5">
-          <h3 className="text-lg font-semibold text-gray-900">
-            Request Access
-          </h3>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-            aria-label="Close"
-          >
-            <svg
-              className="h-5 w-5"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18 18 6M6 6l12 12"
-              />
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div role="dialog" aria-modal="true" className="relative w-full max-w-2xl rounded-2xl bg-white shadow-xl flex flex-col max-h-[90vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-2">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Request Access</h3>
+            <p className="text-sm text-gray-500 mt-0.5">
+              {dataset.title}
+            </p>
+          </div>
+          <button onClick={onClose} className="rounded-lg p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors" aria-label="Close">
+            <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
 
-        <p className="text-sm text-gray-600 mb-5">
-          Requesting access to{' '}
-          <span className="font-semibold text-gray-900">{dataset.title}</span>
-        </p>
+        {/* Step Indicator */}
+        <div className="px-6 pt-4">
+          <StepIndicator />
+        </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          {/* Access Model */}
+        {/* Scrollable Content */}
+        <div className="flex-1 overflow-y-auto px-6 pb-2">
+          {step === 1 && renderStep1()}
+          {step === 2 && renderStep2()}
+          {step === 3 && renderStep3()}
+        </div>
+
+        {/* Footer Navigation */}
+        <div className="flex items-center justify-between border-t border-gray-100 px-6 py-4">
           <div>
-            <label
-              htmlFor="req-access-model"
-              className="block text-sm font-semibold text-gray-700 mb-1.5"
-            >
-              Access Model
-            </label>
-            <select
-              id="req-access-model"
-              value={accessModel}
-              onChange={(e) => setAccessModel(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 focus:outline-none"
-            >
-              {dataset.accessModels.map((model) => (
-                <option key={model} value={model}>
-                  {ACCESS_MODEL_INFO[model]?.label || model}
-                </option>
-              ))}
-            </select>
-            {accessModel && ACCESS_MODEL_INFO[accessModel] && (
-              <p className="mt-1.5 text-xs text-gray-500">
-                {ACCESS_MODEL_INFO[accessModel].description}
-              </p>
+            {step > 1 && (
+              <button
+                type="button"
+                onClick={handleBack}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
+              >
+                Back
+              </button>
             )}
           </div>
-
-          {/* Purpose */}
-          <div>
-            <label
-              htmlFor="req-purpose"
-              className="block text-sm font-semibold text-gray-700 mb-1.5"
-            >
-              Purpose of Access
-            </label>
-            <textarea
-              id="req-purpose"
-              rows={4}
-              value={purpose}
-              onChange={(e) => setPurpose(e.target.value)}
-              placeholder="Describe your research purpose and how you intend to use this dataset..."
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm placeholder:text-gray-400 focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 focus:outline-none resize-none"
-            />
-          </div>
-
-          {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
-            >
+          <div className="flex items-center gap-3">
+            <button type="button" onClick={onClose} className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors">
               Cancel
             </button>
-            <button
-              type="submit"
-              disabled={!purpose.trim() || submitting}
-              className="rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {submitting ? 'Submitting...' : 'Submit Request'}
-            </button>
+            {step < 3 ? (
+              <button
+                type="button"
+                onClick={handleNext}
+                className="rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors"
+              >
+                Next
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {submitting ? 'Submitting...' : 'Submit Request'}
+              </button>
+            )}
           </div>
-        </form>
+        </div>
       </div>
-    </div>
-  );
-}
-
-/* ===== FAIR Score Bar Chart ===== */
-function FairBarChart({ fairScore }) {
-  const maxPerDimension = 5;
-
-  return (
-    <div className="space-y-3">
-      {FAIR_DIMENSIONS.map(({ key, label, color }) => {
-        const score = fairScore[key] || 0;
-        const pct = (score / maxPerDimension) * 100;
-        return (
-          <div key={key}>
-            <div className="flex items-center justify-between text-sm mb-1">
-              <span className="font-medium text-gray-700">{label}</span>
-              <span className="text-gray-500">
-                {score}/{maxPerDimension}
-              </span>
-            </div>
-            <div className="h-2.5 w-full rounded-full bg-gray-100">
-              <div
-                className={`h-2.5 rounded-full ${color} transition-all duration-500`}
-                style={{ width: `${pct}%` }}
-              />
-            </div>
-          </div>
-        );
-      })}
     </div>
   );
 }
@@ -269,58 +606,32 @@ function FairBarChart({ fairScore }) {
 /* ===== Main DatasetDetail Component ===== */
 export default function DatasetDetail() {
   const { id } = useParams();
-  const { getDataset, createRequest, toggleBookmark, isBookmarked } = useData();
+  const { getDataset, searchDatasets, createRequest, toggleBookmark, isBookmarked } = useData();
   const { currentUser, isAuthenticated } = useAuth();
+  const [activeTab, setActiveTab] = useState('overview');
   const [showRequestModal, setShowRequestModal] = useState(false);
 
   const dataset = getDataset(id);
 
-  /* ---- 404 State ---- */
+  const relatedDatasets = useMemo(() => {
+    if (!dataset) return [];
+    return searchDatasets('', {})
+      .filter((ds) => ds.holder.id === dataset.holder.id && ds.id !== dataset.id)
+      .slice(0, 4);
+  }, [dataset, searchDatasets]);
+
   if (!dataset) {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="flex flex-col items-center justify-center text-center">
           <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
-            <svg
-              className="h-8 w-8 text-gray-400"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-              />
+            <svg className="h-8 w-8 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">
-            Dataset Not Found
-          </h1>
-          <p className="text-gray-600 mb-6">
-            The dataset you are looking for does not exist or may have been
-            removed.
-          </p>
-          <Link
-            to="/catalog"
-            className="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors"
-          >
-            <svg
-              className="h-4 w-4"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-              />
-            </svg>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">Dataset Not Found</h1>
+          <p className="text-gray-600 mb-6">The dataset you are looking for does not exist or may have been removed.</p>
+          <Link to="/catalog" className="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors">
             Back to Catalog
           </Link>
         </div>
@@ -328,17 +639,7 @@ export default function DatasetDetail() {
     );
   }
 
-  const isDataUser =
-    isAuthenticated && currentUser?.role === 'data-user';
-  const canBookmark =
-    isAuthenticated &&
-    (currentUser?.role === 'data-user' || currentUser?.role === 'admin');
-  const bookmarked = canBookmark && isBookmarked(dataset.id);
-
-  const orgTypeBadgeClass =
-    dataset.holder.type === 'public'
-      ? 'bg-sky-50 text-sky-700 ring-sky-600/20'
-      : 'bg-teal-50 text-teal-700 ring-teal-600/20';
+  const bookmarked = isAuthenticated && isBookmarked(dataset.id);
 
   const handleRequestSubmit = async ({ accessModel, purpose }) => {
     await createRequest({
@@ -349,463 +650,67 @@ export default function DatasetDetail() {
     });
   };
 
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 'overview':
+        return <OverviewTab dataset={dataset} />;
+      case 'details':
+        return <DetailsTab dataset={dataset} />;
+      case 'dictionary':
+        return <DictionaryTab dataset={dataset} />;
+      case 'sample':
+        return <SampleTab dataset={dataset} />;
+      case 'access':
+        return <AccessTab dataset={dataset} />;
+      case 'use-cases':
+        return <UseCasesTab dataset={dataset} />;
+      case 'publications':
+        return <PublicationsTab dataset={dataset} />;
+      case 'faq':
+        return <FaqTab dataset={dataset} />;
+      default:
+        return <OverviewTab dataset={dataset} />;
+    }
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      {/* Back link */}
-      <Link
-        to="/catalog"
-        className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-600 hover:text-teal-700 mb-6 group"
-      >
-        <svg
-          className="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={2}
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-          />
-        </svg>
-        Back to Catalog
-      </Link>
+      {/* Header */}
+      <DatasetHeader
+        dataset={dataset}
+        isAuthenticated={isAuthenticated}
+        currentUser={currentUser}
+        bookmarked={bookmarked}
+        onToggleBookmark={() => toggleBookmark(dataset.id)}
+        onRequestAccess={() => setShowRequestModal(true)}
+      />
 
-      {/* Header Section */}
-      <div className="mb-8">
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <h1 className="text-3xl font-bold text-gray-900 mb-3">
-              {dataset.title}
-            </h1>
-            <div className="flex flex-wrap items-center gap-3">
-              <span className="text-sm text-gray-600">
-                Held by{' '}
-                <span className="font-semibold text-gray-800">
-                  {dataset.holder.name}
-                </span>
-              </span>
-              <span
-                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset ${orgTypeBadgeClass}`}
-              >
-                {dataset.holder.type === 'public' ? 'Public' : 'Private'}
-              </span>
-            </div>
-          </div>
-
-          {/* Request Access button */}
-          <div className="flex items-center gap-3 shrink-0">
-            {canBookmark && (
-              <button
-                onClick={() => toggleBookmark(dataset.id)}
-                className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors ${
-                  bookmarked
-                    ? 'border-teal-200 bg-teal-50 text-teal-600 hover:bg-teal-100'
-                    : 'border-gray-300 text-gray-400 hover:text-teal-600 hover:border-teal-300'
-                }`}
-                title={bookmarked ? 'Remove bookmark' : 'Bookmark this dataset'}
-              >
-                <svg
-                  className="h-5 w-5"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill={bookmarked ? 'currentColor' : 'none'}
-                  stroke="currentColor"
-                  strokeWidth={bookmarked ? 0 : 1.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z"
-                  />
-                </svg>
-                {bookmarked ? 'Bookmarked' : 'Bookmark'}
-              </button>
-            )}
-            {!isAuthenticated && (
-              <Link
-                to="/login"
-                className="inline-flex items-center gap-2 rounded-lg border border-teal-600 px-5 py-2.5 text-sm font-semibold text-teal-700 hover:bg-teal-50 transition-colors"
-              >
-                Log in to request access
-              </Link>
-            )}
-            {isDataUser && (
-              <button
-                onClick={() => setShowRequestModal(true)}
-                className="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors"
-              >
-                <svg
-                  className="h-4 w-4"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={2}
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-                  />
-                </svg>
-                Request Access
-              </button>
-            )}
-          </div>
-        </div>
+      {/* Tab Navigation */}
+      <div className="border-b border-gray-200 mt-6 mb-8">
+        <nav className="flex gap-0 overflow-x-auto -mb-px" aria-label="Dataset tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`whitespace-nowrap px-5 py-3 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === tab.id
+                  ? 'border-teal-600 text-teal-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
       </div>
 
+      {/* Content + Sidebar */}
       <div className="grid lg:grid-cols-3 gap-8">
-        {/* Left column: Description + Metadata + Columns + Tags */}
-        <div className="lg:col-span-2 space-y-8">
-          {/* Description */}
-          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">
-              Description
-            </h2>
-            <p className="text-gray-700 leading-relaxed">
-              {dataset.description}
-            </p>
-          </section>
-
-          {/* Metadata Grid */}
-          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-              Metadata
-            </h2>
-            <dl className="grid sm:grid-cols-2 gap-x-6 gap-y-4">
-              <div>
-                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Record Count
-                </dt>
-                <dd className="mt-1 text-lg font-semibold text-gray-900">
-                  {formatNumber(dataset.recordCount)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Date Range
-                </dt>
-                <dd className="mt-1 text-lg font-semibold text-gray-900">
-                  {formatDate(dataset.dateRange.from)} &ndash;{' '}
-                  {formatDate(dataset.dateRange.to)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Category
-                </dt>
-                <dd className="mt-1 text-lg font-semibold text-gray-900">
-                  {formatCategory(dataset.category)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Status
-                </dt>
-                <dd className="mt-1">
-                  <span
-                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
-                      dataset.status === 'published'
-                        ? 'bg-green-50 text-green-700 ring-1 ring-inset ring-green-600/20'
-                        : 'bg-gray-100 text-gray-700 ring-1 ring-inset ring-gray-600/20'
-                    }`}
-                  >
-                    {dataset.status.charAt(0).toUpperCase() +
-                      dataset.status.slice(1)}
-                  </span>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Date Added
-                </dt>
-                <dd className="mt-1 text-lg font-semibold text-gray-900">
-                  {formatDate(dataset.createdAt)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Data Holder Type
-                </dt>
-                <dd className="mt-1 text-lg font-semibold text-gray-900">
-                  {dataset.holder.type === 'public'
-                    ? 'Public Organisation'
-                    : 'Private Organisation'}
-                </dd>
-              </div>
-              {dataset.domain && (
-                <div>
-                  <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Domain
-                  </dt>
-                  <dd className="mt-1 text-lg font-semibold text-gray-900">
-                    {formatCategory(dataset.domain)}
-                  </dd>
-                </div>
-              )}
-              {dataset.geographicCoverage && (
-                <div>
-                  <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Geographic Coverage
-                  </dt>
-                  <dd className="mt-1 text-lg font-semibold text-gray-900">
-                    {dataset.geographicCoverage}
-                  </dd>
-                </div>
-              )}
-              {dataset.license && (
-                <div>
-                  <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    License
-                  </dt>
-                  <dd className="mt-1 text-lg font-semibold text-gray-900">
-                    {dataset.license}
-                  </dd>
-                </div>
-              )}
-            </dl>
-          </section>
-
-          {/* Columns / Fields */}
-          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">
-              Fields / Columns
-              <span className="ml-2 text-gray-400 font-normal normal-case tracking-normal">
-                ({dataset.columns.length})
-              </span>
-            </h2>
-            <div className="flex flex-wrap gap-2">
-              {dataset.columns.map((col) => (
-                <span
-                  key={col}
-                  className="inline-flex items-center rounded-md bg-gray-100 px-2.5 py-1 text-xs font-mono font-medium text-gray-700 ring-1 ring-inset ring-gray-200"
-                >
-                  {col}
-                </span>
-              ))}
-            </div>
-          </section>
-
-          {/* Tags */}
-          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">
-              Tags
-            </h2>
-            <div className="flex flex-wrap gap-2">
-              {dataset.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center rounded-full bg-teal-50 px-3 py-1 text-xs font-medium text-teal-700 ring-1 ring-inset ring-teal-600/20"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </section>
-
-          {/* Data Standards */}
-          {dataset.dataStandards?.length > 0 && (
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">
-                Data Standards
-              </h2>
-              <div className="flex flex-wrap gap-2">
-                {dataset.dataStandards.map((std) => (
-                  <span key={std} className="inline-flex items-center rounded-full bg-teal-50 px-3 py-1 text-xs font-medium text-teal-700 ring-1 ring-inset ring-teal-600/20">
-                    {std}
-                  </span>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* Access Models */}
-          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-              Available Access Models
-            </h2>
-            <div className="space-y-4">
-              {dataset.accessModels.map((model) => {
-                const info = ACCESS_MODEL_INFO[model];
-                const style = ACCESS_MODEL_STYLES[model] || {};
-                return (
-                  <div
-                    key={model}
-                    className={`flex items-start gap-3 rounded-lg border border-gray-100 bg-gray-50 p-4 border-l-4 ${style.borderLeft || 'border-l-gray-300'}`}
-                  >
-                    <div className="shrink-0 mt-0.5">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-teal-100">
-                        <svg
-                          className="h-4 w-4 text-teal-600"
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth={2}
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-semibold text-gray-900">
-                        {info?.label || model}
-                      </h3>
-                      <p className="text-sm text-gray-600 mt-0.5">
-                        {info?.description || 'No description available.'}
-                      </p>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </section>
+        <div className="lg:col-span-2">
+          {renderTabContent()}
         </div>
-
-        {/* Right column: FAIR Score + Quick actions */}
-        <div className="space-y-6">
-          {/* FAIR Score Card */}
-          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm sticky top-24">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-              FAIR Score
-            </h2>
-
-            {/* Total score circle */}
-            <div className="flex items-center justify-center mb-6">
-              <div className="relative flex items-center justify-center">
-                <svg className="h-28 w-28" viewBox="0 0 120 120">
-                  <circle
-                    cx="60"
-                    cy="60"
-                    r="52"
-                    fill="none"
-                    stroke="#f3f4f6"
-                    strokeWidth="8"
-                  />
-                  <circle
-                    cx="60"
-                    cy="60"
-                    r="52"
-                    fill="none"
-                    stroke={
-                      dataset.fairScore.total >= 16
-                        ? '#0d9488'
-                        : dataset.fairScore.total >= 12
-                          ? '#0284c7'
-                          : dataset.fairScore.total >= 8
-                            ? '#d97706'
-                            : '#dc2626'
-                    }
-                    strokeWidth="8"
-                    strokeLinecap="round"
-                    strokeDasharray={`${(dataset.fairScore.total / 20) * 327} 327`}
-                    transform="rotate(-90 60 60)"
-                    className="transition-all duration-500"
-                  />
-                </svg>
-                <div className="absolute inset-0 flex flex-col items-center justify-center">
-                  <span className="text-2xl font-bold text-gray-900">
-                    {dataset.fairScore.total}
-                  </span>
-                  <span className="text-xs text-gray-500">/ 20</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Label */}
-            <div className="text-center mb-6">
-              <span
-                className={`text-sm font-semibold ${getFairColor(dataset.fairScore.total)}`}
-              >
-                {getFairLabel(dataset.fairScore.total)}
-              </span>
-            </div>
-
-            {/* Dimension Breakdown */}
-            <FairBarChart fairScore={dataset.fairScore} />
-
-            {/* Request button (repeated for sticky sidebar visibility) */}
-            {isDataUser && (
-              <button
-                onClick={() => setShowRequestModal(true)}
-                className="mt-6 w-full rounded-lg bg-teal-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 transition-colors"
-              >
-                Request Access
-              </button>
-            )}
-          </div>
-
-          {/* Quick Info Card */}
-          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-              Quick Info
-            </h2>
-            <dl className="space-y-3">
-              <div className="flex items-center justify-between text-sm">
-                <dt className="text-gray-500">Records</dt>
-                <dd className="font-medium text-gray-900">
-                  {formatNumber(dataset.recordCount)}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between text-sm">
-                <dt className="text-gray-500">Fields</dt>
-                <dd className="font-medium text-gray-900">
-                  {dataset.columns.length}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between text-sm">
-                <dt className="text-gray-500">Access Models</dt>
-                <dd className="font-medium text-gray-900">
-                  {dataset.accessModels.length}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between text-sm">
-                <dt className="text-gray-500">Category</dt>
-                <dd className="font-medium text-gray-900">
-                  {formatCategory(dataset.category)}
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          {/* Contact Data Holder Card */}
-          {(dataset.holder.contactEmail || dataset.holder.contactPhone) && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-                Contact Data Holder
-              </h2>
-              <dl className="space-y-3">
-                {dataset.holder.contactEmail && (
-                  <div>
-                    <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">Email</dt>
-                    <dd className="mt-1">
-                      <a href={`mailto:${dataset.holder.contactEmail}`} className="text-sm text-teal-600 hover:text-teal-700 font-medium">
-                        {dataset.holder.contactEmail}
-                      </a>
-                    </dd>
-                  </div>
-                )}
-                {dataset.holder.contactPhone && (
-                  <div>
-                    <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</dt>
-                    <dd className="mt-1">
-                      <a href={`tel:${dataset.holder.contactPhone}`} className="text-sm text-gray-700 font-medium">
-                        {dataset.holder.contactPhone}
-                      </a>
-                    </dd>
-                  </div>
-                )}
-              </dl>
-            </div>
-          )}
+        <div>
+          <DatasetSidebar dataset={dataset} relatedDatasets={relatedDatasets} />
         </div>
       </div>
 

--- a/src/pages/dashboard/NewDataset.jsx
+++ b/src/pages/dashboard/NewDataset.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
 import { useData } from '../../context/DataContext';
+import { useAuth } from '../../context/AuthContext';
 import { calculateFairScore, getFairLabel, getFairColor } from '../../utils/fairScore';
 import FairBadge from '../../components/FairBadge';
 
@@ -23,6 +23,44 @@ const ACCESS_MODEL_OPTIONS = [
   { value: 'metadata-light', label: 'Metadata Light' },
 ];
 
+const DATA_TYPE_OPTIONS = [
+  'Clinical/Journal',
+  'Genomics/Bioinformatics',
+  'Imaging',
+  'Biobank/Samples',
+  'Physiological',
+];
+
+const FILE_FORMAT_OPTIONS = [
+  'CSV', 'TSV', 'JSON', 'Parquet', 'Excel', 'DICOM',
+  'FHIR/JSON', 'HL7', 'VCF', 'BAM/CRAM', 'PDF', 'XML', 'HDF5', 'SQLite',
+];
+
+const SENSITIVITY_LEVELS = [
+  { value: '', label: 'Select sensitivity level...' },
+  { value: 'Special Category', label: 'Special Category' },
+  { value: 'Pseudonymized', label: 'Pseudonymized' },
+  { value: 'Anonymized', label: 'Anonymized' },
+  { value: 'Aggregated', label: 'Aggregated' },
+];
+
+const LICENSE_OPTIONS = [
+  { value: '', label: 'Select license...' },
+  { value: 'CC BY 4.0', label: 'CC BY 4.0' },
+  { value: 'CC BY-NC 4.0', label: 'CC BY-NC 4.0' },
+  { value: 'Research Only', label: 'Research Only' },
+  { value: 'Custom DUA Required', label: 'Custom DUA Required' },
+];
+
+const UPDATE_FREQUENCY_OPTIONS = [
+  { value: '', label: 'Select frequency...' },
+  { value: 'One-time', label: 'One-time' },
+  { value: 'Monthly', label: 'Monthly' },
+  { value: 'Quarterly', label: 'Quarterly' },
+  { value: 'Annual', label: 'Annual' },
+  { value: 'Ongoing', label: 'Ongoing' },
+];
+
 const INITIAL_FORM = {
   title: '',
   description: '',
@@ -33,7 +71,57 @@ const INITIAL_FORM = {
   dateFrom: '',
   dateTo: '',
   accessModels: [],
+  dataTypes: [],
+  fileFormats: [],
+  customFileFormat: '',
+  sensitivityLevel: '',
+  dataSize: '',
+  cohortAgeRange: '',
+  cohortSexMale: '',
+  cohortSexFemale: '',
+  cohortGeographicArea: '',
+  cohortSampleSize: '',
+  cohortDescription: '',
+  license: '',
+  methodology: '',
+  limitations: '',
+  updateFrequency: '',
+  useCases: [],
+  publications: [],
+  faq: [],
 };
+
+/* ── Chevron icon ──────────────────────────────────────────────── */
+function ChevronIcon({ open }) {
+  return (
+    <svg
+      className={`h-4 w-4 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+    </svg>
+  );
+}
+
+/* ── Section wrapper ───────────────────────────────────────────── */
+function Section({ title, open, onToggle, alwaysOpen, children }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg shadow-sm">
+      <button
+        type="button"
+        onClick={alwaysOpen ? undefined : onToggle}
+        className={`flex items-center justify-between w-full px-6 py-3 text-left text-sm font-semibold text-gray-900 ${alwaysOpen ? 'cursor-default' : 'cursor-pointer'}`}
+      >
+        {title}
+        {!alwaysOpen && <ChevronIcon open={open} />}
+      </button>
+      {open && <div className="px-6 pb-6 space-y-5">{children}</div>}
+    </div>
+  );
+}
 
 export default function NewDataset() {
   const { currentUser } = useAuth();
@@ -44,6 +132,20 @@ export default function NewDataset() {
   const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
 
+  const [openSections, setOpenSections] = useState(
+    new Set(['basic', 'data-char', 'records', 'cohort', 'access', 'enrichment', 'methodology'])
+  );
+
+  const toggleSection = (id) => {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  /* ── Field helpers ─────────────────────────────────────────── */
   const update = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
@@ -55,24 +157,80 @@ export default function NewDataset() {
     }
   };
 
-  const toggleAccessModel = (model) => {
+  const toggleMulti = (field, value) => {
     setForm((prev) => {
-      const current = prev.accessModels;
-      const next = current.includes(model)
-        ? current.filter((m) => m !== model)
-        : [...current, model];
-      return { ...prev, accessModels: next };
+      const current = prev[field];
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value];
+      return { ...prev, [field]: next };
     });
-    if (errors.accessModels) {
+    if (errors[field]) {
       setErrors((prev) => {
         const next = { ...prev };
-        delete next.accessModels;
+        delete next[field];
         return next;
       });
     }
   };
 
-  // Build a preview dataset object for live FAIR score calculation
+  /* ── Dynamic list helpers ──────────────────────────────────── */
+  const addUseCase = () =>
+    setForm((prev) => ({
+      ...prev,
+      useCases: [...prev.useCases, { title: '', description: '' }],
+    }));
+  const removeUseCase = (idx) =>
+    setForm((prev) => ({
+      ...prev,
+      useCases: prev.useCases.filter((_, i) => i !== idx),
+    }));
+  const updateUseCase = (idx, field, value) =>
+    setForm((prev) => ({
+      ...prev,
+      useCases: prev.useCases.map((uc, i) =>
+        i === idx ? { ...uc, [field]: value } : uc
+      ),
+    }));
+
+  const addPublication = () =>
+    setForm((prev) => ({
+      ...prev,
+      publications: [
+        ...prev.publications,
+        { title: '', authors: '', journal: '', year: '', doi: '', url: '' },
+      ],
+    }));
+  const removePublication = (idx) =>
+    setForm((prev) => ({
+      ...prev,
+      publications: prev.publications.filter((_, i) => i !== idx),
+    }));
+  const updatePublication = (idx, field, value) =>
+    setForm((prev) => ({
+      ...prev,
+      publications: prev.publications.map((pub, i) =>
+        i === idx ? { ...pub, [field]: value } : pub
+      ),
+    }));
+
+  const addFaq = () =>
+    setForm((prev) => ({
+      ...prev,
+      faq: [...prev.faq, { question: '', answer: '' }],
+    }));
+  const removeFaq = (idx) =>
+    setForm((prev) => ({
+      ...prev,
+      faq: prev.faq.filter((_, i) => i !== idx),
+    }));
+  const updateFaq = (idx, field, value) =>
+    setForm((prev) => ({
+      ...prev,
+      faq: prev.faq.map((f, i) => (i === idx ? { ...f, [field]: value } : f)),
+    }));
+
+  /* ── FAIR preview ──────────────────────────────────────────── */
   const previewDataset = useMemo(() => {
     const parsedTags = form.tags
       .split(',')
@@ -96,6 +254,7 @@ export default function NewDataset() {
           ? { from: form.dateFrom, to: form.dateTo }
           : null,
       accessModels: form.accessModels,
+      license: form.license,
       holder: currentUser
         ? { id: currentUser.id, name: currentUser.organization }
         : null,
@@ -108,17 +267,18 @@ export default function NewDataset() {
     [previewDataset]
   );
 
+  /* ── Validation ────────────────────────────────────────────── */
   const validate = () => {
     const newErrors = {};
     if (!form.title.trim()) newErrors.title = 'Title is required';
-    if (!form.description.trim())
-      newErrors.description = 'Description is required';
+    if (!form.description.trim()) newErrors.description = 'Description is required';
     if (!form.category) newErrors.category = 'Category is required';
     if (form.accessModels.length === 0)
       newErrors.accessModels = 'Select at least one access model';
     return newErrors;
   };
 
+  /* ── Submit ────────────────────────────────────────────────── */
   const handleSubmit = (e) => {
     e.preventDefault();
     const newErrors = validate();
@@ -139,6 +299,34 @@ export default function NewDataset() {
       .filter(Boolean);
     const recordCount = parseInt(form.recordCount, 10) || 0;
 
+    // Build fileFormats — append custom if provided
+    const fileFormats = form.customFileFormat.trim()
+      ? [...form.fileFormats, form.customFileFormat.trim()]
+      : [...form.fileFormats];
+
+    // Build cohort object
+    const cohort = {
+      ageRange: form.cohortAgeRange.trim(),
+      sexDistribution: {
+        male: Number(form.cohortSexMale) || 0,
+        female: Number(form.cohortSexFemale) || 0,
+      },
+      geographicArea: form.cohortGeographicArea.trim(),
+      sampleSize: Number(form.cohortSampleSize) || 0,
+      description: form.cohortDescription.trim(),
+    };
+
+    // Filter empty dynamic entries
+    const useCases = form.useCases.filter(
+      (uc) => uc.title.trim() || uc.description.trim()
+    );
+    const publications = form.publications.filter(
+      (pub) => pub.title.trim() || pub.authors.trim()
+    );
+    const faq = form.faq.filter(
+      (f) => f.question.trim() || f.answer.trim()
+    );
+
     addDataset({
       title: form.title.trim(),
       description: form.description.trim(),
@@ -151,10 +339,23 @@ export default function NewDataset() {
           ? { from: form.dateFrom, to: form.dateTo }
           : null,
       accessModels: form.accessModels,
+      dataTypes: form.dataTypes,
+      fileFormats,
+      sensitivityLevel: form.sensitivityLevel,
+      dataSize: form.dataSize.trim(),
+      cohort,
+      license: form.license,
+      methodology: form.methodology.trim(),
+      limitations: form.limitations.trim(),
+      updateFrequency: form.updateFrequency,
+      useCases,
+      publications,
+      faq,
       holder: {
         id: currentUser?.id ?? 'unknown',
         name: currentUser?.organization ?? 'Unknown',
-        type: currentUser?.membershipTier === 'strategic' ? 'private' : 'public',
+        type:
+          currentUser?.membershipTier === 'strategic' ? 'private' : 'public',
       },
       status: 'draft',
     });
@@ -162,20 +363,20 @@ export default function NewDataset() {
     navigate('/dashboard/holder');
   };
 
+  /* ── Style helpers ─────────────────────────────────────────── */
+  const inputBase =
+    'rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 focus:outline-none';
+  const inputError =
+    'rounded-lg border border-red-400 px-3 py-2 text-sm focus:border-red-500 focus:ring-2 focus:ring-red-500/20 focus:outline-none';
+
   const inputClass = (field) =>
-    `block w-full rounded-md border px-3 py-2 text-sm text-gray-900 placeholder-gray-400 outline-none transition-colors ${
-      errors[field]
-        ? 'border-red-400 focus:border-red-500 focus:ring-1 focus:ring-red-500'
-        : 'border-gray-300 focus:border-teal-600 focus:ring-1 focus:ring-teal-600'
-    }`;
+    `block w-full ${errors[field] ? inputError : inputBase}`;
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Page header */}
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">
-          Register New Dataset
-        </h1>
+        <h1 className="text-2xl font-bold text-gray-900">Register New Dataset</h1>
         <p className="mt-1 text-sm text-gray-500">
           Fill in the details below to register a dataset for{' '}
           {currentUser?.organization}.
@@ -184,16 +385,19 @@ export default function NewDataset() {
 
       <form onSubmit={handleSubmit}>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* ── Left column: form fields ────────────────────────────── */}
-          <div className="lg:col-span-2 space-y-6">
-            <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6 space-y-5">
+          {/* ── Left column: form sections ─────────────────────── */}
+          <div className="lg:col-span-2 space-y-4">
+            {/* ═══ 1. Basic Information ═══════════════════════════ */}
+            <Section
+              id="basic"
+              title="Basic Information"
+              open={true}
+              alwaysOpen
+            >
               {/* Title */}
               <div>
-                <label
-                  htmlFor="title"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Title
+                <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+                  Title <span className="text-red-500">*</span>
                 </label>
                 <input
                   id="title"
@@ -203,18 +407,13 @@ export default function NewDataset() {
                   className={inputClass('title')}
                   placeholder="e.g. Regional Patient Flow Data 2019-2023"
                 />
-                {errors.title && (
-                  <p className="mt-1 text-xs text-red-600">{errors.title}</p>
-                )}
+                {errors.title && <p className="mt-1 text-xs text-red-600">{errors.title}</p>}
               </div>
 
               {/* Description */}
               <div>
-                <label
-                  htmlFor="description"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Description
+                <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                  Description <span className="text-red-500">*</span>
                 </label>
                 <textarea
                   id="description"
@@ -225,20 +424,15 @@ export default function NewDataset() {
                   placeholder="Describe the dataset contents, provenance, and intended use..."
                 />
                 {errors.description && (
-                  <p className="mt-1 text-xs text-red-600">
-                    {errors.description}
-                  </p>
+                  <p className="mt-1 text-xs text-red-600">{errors.description}</p>
                 )}
               </div>
 
-              {/* Category + Tags (two columns) */}
+              {/* Category + Tags */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
                 <div>
-                  <label
-                    htmlFor="category"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    Category
+                  <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-1">
+                    Category <span className="text-red-500">*</span>
                   </label>
                   <select
                     id="category"
@@ -253,17 +447,11 @@ export default function NewDataset() {
                     ))}
                   </select>
                   {errors.category && (
-                    <p className="mt-1 text-xs text-red-600">
-                      {errors.category}
-                    </p>
+                    <p className="mt-1 text-xs text-red-600">{errors.category}</p>
                   )}
                 </div>
-
                 <div>
-                  <label
-                    htmlFor="tags"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
+                  <label htmlFor="tags" className="block text-sm font-medium text-gray-700 mb-1">
                     Tags
                   </label>
                   <input
@@ -276,15 +464,111 @@ export default function NewDataset() {
                   />
                 </div>
               </div>
+            </Section>
 
-              {/* Record count + Columns (two columns) */}
+            {/* ═══ 2. Data Characteristics ════════════════════════ */}
+            <Section
+              id="data-char"
+              title="Data Characteristics"
+              open={openSections.has('data-char')}
+              onToggle={() => toggleSection('data-char')}
+            >
+              {/* Data Types */}
+              <div>
+                <span className="block text-sm font-medium text-gray-700 mb-2">Data Types</span>
+                <div className="flex flex-wrap gap-x-5 gap-y-2">
+                  {DATA_TYPE_OPTIONS.map((dt) => (
+                    <label key={dt} className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={form.dataTypes.includes(dt)}
+                        onChange={() => toggleMulti('dataTypes', dt)}
+                        className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                      />
+                      <span className="text-sm text-gray-700">{dt}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {/* File Formats */}
+              <div>
+                <span className="block text-sm font-medium text-gray-700 mb-2">File Formats</span>
+                <div className="flex flex-wrap gap-x-5 gap-y-2">
+                  {FILE_FORMAT_OPTIONS.map((ff) => (
+                    <label key={ff} className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={form.fileFormats.includes(ff)}
+                        onChange={() => toggleMulti('fileFormats', ff)}
+                        className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                      />
+                      <span className="text-sm text-gray-700">{ff}</span>
+                    </label>
+                  ))}
+                </div>
+                <div className="mt-3">
+                  <label htmlFor="customFileFormat" className="block text-xs font-medium text-gray-500 mb-1">
+                    Other format
+                  </label>
+                  <input
+                    id="customFileFormat"
+                    type="text"
+                    value={form.customFileFormat}
+                    onChange={(e) => update('customFileFormat', e.target.value)}
+                    className={`${inputBase} w-full sm:w-56`}
+                    placeholder="e.g. NIFTI, FASTQ"
+                  />
+                </div>
+              </div>
+
+              {/* Sensitivity Level + Dataset Size */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
                 <div>
-                  <label
-                    htmlFor="recordCount"
-                    className="block text-sm font-medium text-gray-700 mb-1"
+                  <label htmlFor="sensitivityLevel" className="block text-sm font-medium text-gray-700 mb-1">
+                    Sensitivity Level
+                  </label>
+                  <select
+                    id="sensitivityLevel"
+                    value={form.sensitivityLevel}
+                    onChange={(e) => update('sensitivityLevel', e.target.value)}
+                    className={`${inputBase} bg-white w-full`}
                   >
-                    Record count
+                    {SENSITIVITY_LEVELS.map((sl) => (
+                      <option key={sl.value} value={sl.value}>
+                        {sl.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="dataSize" className="block text-sm font-medium text-gray-700 mb-1">
+                    Dataset Size
+                  </label>
+                  <input
+                    id="dataSize"
+                    type="text"
+                    value={form.dataSize}
+                    onChange={(e) => update('dataSize', e.target.value)}
+                    className={`${inputBase} w-full`}
+                    placeholder="e.g., 2.3 GB"
+                  />
+                </div>
+              </div>
+            </Section>
+
+            {/* ═══ 3. Records & Schema ════════════════════════════ */}
+            <Section
+              id="records"
+              title="Records & Schema"
+              open={openSections.has('records')}
+              onToggle={() => toggleSection('records')}
+            >
+              {/* Record Count + Columns */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+                <div>
+                  <label htmlFor="recordCount" className="block text-sm font-medium text-gray-700 mb-1">
+                    Record Count
                   </label>
                   <input
                     id="recordCount"
@@ -292,112 +576,473 @@ export default function NewDataset() {
                     min="0"
                     value={form.recordCount}
                     onChange={(e) => update('recordCount', e.target.value)}
-                    className={inputClass('recordCount')}
+                    className={`${inputBase} w-full`}
                     placeholder="e.g. 245000"
                   />
                 </div>
-
                 <div>
-                  <label
-                    htmlFor="columns"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    Columns
+                  <label htmlFor="columns" className="block text-sm font-medium text-gray-700 mb-1">
+                    Columns / Fields
                   </label>
                   <input
                     id="columns"
                     type="text"
                     value={form.columns}
                     onChange={(e) => update('columns', e.target.value)}
-                    className={inputClass('columns')}
+                    className={`${inputBase} w-full`}
                     placeholder="comma-separated, e.g. patient_id, date, diagnosis"
                   />
                 </div>
               </div>
 
-              {/* Date range (two columns) */}
+              {/* Date Range */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
                 <div>
-                  <label
-                    htmlFor="dateFrom"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    Date range from
+                  <label htmlFor="dateFrom" className="block text-sm font-medium text-gray-700 mb-1">
+                    Date Range From
                   </label>
                   <input
                     id="dateFrom"
                     type="date"
                     value={form.dateFrom}
                     onChange={(e) => update('dateFrom', e.target.value)}
-                    className={inputClass('dateFrom')}
+                    className={`${inputBase} w-full`}
                   />
                 </div>
                 <div>
-                  <label
-                    htmlFor="dateTo"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    Date range to
+                  <label htmlFor="dateTo" className="block text-sm font-medium text-gray-700 mb-1">
+                    Date Range To
                   </label>
                   <input
                     id="dateTo"
                     type="date"
                     value={form.dateTo}
                     onChange={(e) => update('dateTo', e.target.value)}
-                    className={inputClass('dateTo')}
+                    className={`${inputBase} w-full`}
+                  />
+                </div>
+              </div>
+            </Section>
+
+            {/* ═══ 4. Cohort Description ═════════════════════════ */}
+            <Section
+              id="cohort"
+              title="Cohort Description"
+              open={openSections.has('cohort')}
+              onToggle={() => toggleSection('cohort')}
+            >
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+                <div>
+                  <label htmlFor="cohortAgeRange" className="block text-sm font-medium text-gray-700 mb-1">
+                    Age Range
+                  </label>
+                  <input
+                    id="cohortAgeRange"
+                    type="text"
+                    value={form.cohortAgeRange}
+                    onChange={(e) => update('cohortAgeRange', e.target.value)}
+                    className={`${inputBase} w-full`}
+                    placeholder="e.g., 18-85"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="cohortGeographicArea" className="block text-sm font-medium text-gray-700 mb-1">
+                    Geographic Area
+                  </label>
+                  <input
+                    id="cohortGeographicArea"
+                    type="text"
+                    value={form.cohortGeographicArea}
+                    onChange={(e) => update('cohortGeographicArea', e.target.value)}
+                    className={`${inputBase} w-full`}
+                    placeholder="e.g., Western Sweden"
                   />
                 </div>
               </div>
 
-              {/* Access models (checkboxes) */}
+              {/* Sex Distribution */}
+              <div>
+                <span className="block text-sm font-medium text-gray-700 mb-2">Sex Distribution (%)</span>
+                <div className="grid grid-cols-2 gap-5">
+                  <div>
+                    <label htmlFor="cohortSexMale" className="block text-xs text-gray-500 mb-1">
+                      Male %
+                    </label>
+                    <input
+                      id="cohortSexMale"
+                      type="number"
+                      min="0"
+                      max="100"
+                      value={form.cohortSexMale}
+                      onChange={(e) => update('cohortSexMale', e.target.value)}
+                      className={`${inputBase} w-full`}
+                      placeholder="0-100"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="cohortSexFemale" className="block text-xs text-gray-500 mb-1">
+                      Female %
+                    </label>
+                    <input
+                      id="cohortSexFemale"
+                      type="number"
+                      min="0"
+                      max="100"
+                      value={form.cohortSexFemale}
+                      onChange={(e) => update('cohortSexFemale', e.target.value)}
+                      className={`${inputBase} w-full`}
+                      placeholder="0-100"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+                <div>
+                  <label htmlFor="cohortSampleSize" className="block text-sm font-medium text-gray-700 mb-1">
+                    Sample Size
+                  </label>
+                  <input
+                    id="cohortSampleSize"
+                    type="number"
+                    min="0"
+                    value={form.cohortSampleSize}
+                    onChange={(e) => update('cohortSampleSize', e.target.value)}
+                    className={`${inputBase} w-full`}
+                    placeholder="e.g. 5000"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="cohortDescription" className="block text-sm font-medium text-gray-700 mb-1">
+                  Description
+                </label>
+                <textarea
+                  id="cohortDescription"
+                  rows={3}
+                  value={form.cohortDescription}
+                  onChange={(e) => update('cohortDescription', e.target.value)}
+                  className={`${inputBase} w-full`}
+                  placeholder="Describe conditions, biomarkers, inclusion/exclusion criteria..."
+                />
+              </div>
+            </Section>
+
+            {/* ═══ 5. Access & Compliance ═════════════════════════ */}
+            <Section
+              id="access"
+              title="Access & Compliance"
+              open={openSections.has('access')}
+              onToggle={() => toggleSection('access')}
+            >
+              {/* Access Models */}
               <div>
                 <span className="block text-sm font-medium text-gray-700 mb-2">
-                  Access models
+                  Access Models <span className="text-red-500">*</span>
                 </span>
                 <div className="space-y-2">
                   {ACCESS_MODEL_OPTIONS.map((opt) => (
-                    <label
-                      key={opt.value}
-                      className="flex items-center gap-3 cursor-pointer"
-                    >
+                    <label key={opt.value} className="flex items-center gap-3 cursor-pointer">
                       <input
                         type="checkbox"
                         checked={form.accessModels.includes(opt.value)}
-                        onChange={() => toggleAccessModel(opt.value)}
-                        className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600"
+                        onChange={() => toggleMulti('accessModels', opt.value)}
+                        className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
                       />
                       <span className="text-sm text-gray-700">{opt.label}</span>
                     </label>
                   ))}
                 </div>
                 {errors.accessModels && (
-                  <p className="mt-1 text-xs text-red-600">
-                    {errors.accessModels}
-                  </p>
+                  <p className="mt-1 text-xs text-red-600">{errors.accessModels}</p>
                 )}
               </div>
-            </div>
 
-            {/* Submit button */}
-            <div className="flex items-center gap-3">
+              {/* License */}
+              <div>
+                <label htmlFor="license" className="block text-sm font-medium text-gray-700 mb-1">
+                  License
+                </label>
+                <select
+                  id="license"
+                  value={form.license}
+                  onChange={(e) => update('license', e.target.value)}
+                  className={`${inputBase} bg-white w-full`}
+                >
+                  {LICENSE_OPTIONS.map((l) => (
+                    <option key={l.value} value={l.value}>
+                      {l.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </Section>
+
+            {/* ═══ 6. Enrichment ══════════════════════════════════ */}
+            <Section
+              id="enrichment"
+              title="Enrichment (optional)"
+              open={openSections.has('enrichment')}
+              onToggle={() => toggleSection('enrichment')}
+            >
+              {/* Use Cases */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-gray-700">Use Cases</span>
+                  <button
+                    type="button"
+                    onClick={addUseCase}
+                    className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                    </svg>
+                    Add Use Case
+                  </button>
+                </div>
+                {form.useCases.length === 0 && (
+                  <p className="text-xs text-gray-400">No use cases added yet.</p>
+                )}
+                <div className="space-y-3">
+                  {form.useCases.map((uc, idx) => (
+                    <div key={idx} className="border border-gray-200 rounded-lg p-3 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-gray-500">Use Case {idx + 1}</span>
+                        <button
+                          type="button"
+                          onClick={() => removeUseCase(idx)}
+                          className="text-sm text-red-500 hover:text-red-600"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <input
+                        type="text"
+                        value={uc.title}
+                        onChange={(e) => updateUseCase(idx, 'title', e.target.value)}
+                        className={`${inputBase} w-full`}
+                        placeholder="Title"
+                      />
+                      <textarea
+                        rows={2}
+                        value={uc.description}
+                        onChange={(e) => updateUseCase(idx, 'description', e.target.value)}
+                        className={`${inputBase} w-full`}
+                        placeholder="Description"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Publications */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-gray-700">Publications</span>
+                  <button
+                    type="button"
+                    onClick={addPublication}
+                    className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                    </svg>
+                    Add Publication
+                  </button>
+                </div>
+                {form.publications.length === 0 && (
+                  <p className="text-xs text-gray-400">No publications added yet.</p>
+                )}
+                <div className="space-y-3">
+                  {form.publications.map((pub, idx) => (
+                    <div key={idx} className="border border-gray-200 rounded-lg p-3 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-gray-500">Publication {idx + 1}</span>
+                        <button
+                          type="button"
+                          onClick={() => removePublication(idx)}
+                          className="text-sm text-red-500 hover:text-red-600"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <input
+                        type="text"
+                        value={pub.title}
+                        onChange={(e) => updatePublication(idx, 'title', e.target.value)}
+                        className={`${inputBase} w-full`}
+                        placeholder="Title"
+                      />
+                      <div className="grid grid-cols-2 gap-2">
+                        <input
+                          type="text"
+                          value={pub.authors}
+                          onChange={(e) => updatePublication(idx, 'authors', e.target.value)}
+                          className={`${inputBase} w-full`}
+                          placeholder="Authors"
+                        />
+                        <input
+                          type="text"
+                          value={pub.journal}
+                          onChange={(e) => updatePublication(idx, 'journal', e.target.value)}
+                          className={`${inputBase} w-full`}
+                          placeholder="Journal"
+                        />
+                      </div>
+                      <div className="grid grid-cols-3 gap-2">
+                        <input
+                          type="text"
+                          value={pub.year}
+                          onChange={(e) => updatePublication(idx, 'year', e.target.value)}
+                          className={`${inputBase} w-full`}
+                          placeholder="Year"
+                        />
+                        <input
+                          type="text"
+                          value={pub.doi}
+                          onChange={(e) => updatePublication(idx, 'doi', e.target.value)}
+                          className={`${inputBase} w-full`}
+                          placeholder="DOI"
+                        />
+                        <input
+                          type="text"
+                          value={pub.url}
+                          onChange={(e) => updatePublication(idx, 'url', e.target.value)}
+                          className={`${inputBase} w-full`}
+                          placeholder="URL"
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* FAQ */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-gray-700">FAQ</span>
+                  <button
+                    type="button"
+                    onClick={addFaq}
+                    className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                    </svg>
+                    Add FAQ
+                  </button>
+                </div>
+                {form.faq.length === 0 && (
+                  <p className="text-xs text-gray-400">No FAQ entries added yet.</p>
+                )}
+                <div className="space-y-3">
+                  {form.faq.map((f, idx) => (
+                    <div key={idx} className="border border-gray-200 rounded-lg p-3 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-gray-500">FAQ {idx + 1}</span>
+                        <button
+                          type="button"
+                          onClick={() => removeFaq(idx)}
+                          className="text-sm text-red-500 hover:text-red-600"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <input
+                        type="text"
+                        value={f.question}
+                        onChange={(e) => updateFaq(idx, 'question', e.target.value)}
+                        className={`${inputBase} w-full`}
+                        placeholder="Question"
+                      />
+                      <textarea
+                        rows={2}
+                        value={f.answer}
+                        onChange={(e) => updateFaq(idx, 'answer', e.target.value)}
+                        className={`${inputBase} w-full`}
+                        placeholder="Answer"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </Section>
+
+            {/* ═══ 7. Methodology & Limitations ══════════════════ */}
+            <Section
+              id="methodology"
+              title="Methodology & Limitations (optional)"
+              open={openSections.has('methodology')}
+              onToggle={() => toggleSection('methodology')}
+            >
+              <div>
+                <label htmlFor="methodology" className="block text-sm font-medium text-gray-700 mb-1">
+                  Methodology
+                </label>
+                <textarea
+                  id="methodology"
+                  rows={4}
+                  value={form.methodology}
+                  onChange={(e) => update('methodology', e.target.value)}
+                  className={`${inputBase} w-full`}
+                  placeholder="Describe data collection methods, study design, instruments used..."
+                />
+              </div>
+
+              <div>
+                <label htmlFor="limitations" className="block text-sm font-medium text-gray-700 mb-1">
+                  Limitations
+                </label>
+                <textarea
+                  id="limitations"
+                  rows={3}
+                  value={form.limitations}
+                  onChange={(e) => update('limitations', e.target.value)}
+                  className={`${inputBase} w-full`}
+                  placeholder="Known limitations, biases, or caveats..."
+                />
+              </div>
+
+              <div>
+                <label htmlFor="updateFrequency" className="block text-sm font-medium text-gray-700 mb-1">
+                  Update Frequency
+                </label>
+                <select
+                  id="updateFrequency"
+                  value={form.updateFrequency}
+                  onChange={(e) => update('updateFrequency', e.target.value)}
+                  className={`${inputBase} bg-white w-full`}
+                >
+                  {UPDATE_FREQUENCY_OPTIONS.map((uf) => (
+                    <option key={uf.value} value={uf.value}>
+                      {uf.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </Section>
+
+            {/* Submit buttons */}
+            <div className="flex items-center gap-3 pt-2">
               <button
                 type="submit"
                 disabled={submitting}
-                className="inline-flex items-center rounded-md bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {submitting ? 'Registering...' : 'Register Dataset'}
               </button>
               <button
                 type="button"
                 onClick={() => navigate('/dashboard/holder')}
-                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               >
                 Cancel
               </button>
             </div>
           </div>
 
-          {/* ── Right column: live FAIR score preview ────────────────── */}
+          {/* ── Right column: live FAIR score preview ──────────── */}
           <div className="lg:col-span-1">
             <div className="sticky top-24 space-y-4">
               <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
@@ -406,9 +1051,7 @@ export default function NewDataset() {
                 </h3>
                 <FairBadge score={fairScore} detailed />
                 <div className="mt-3 text-center">
-                  <span
-                    className={`text-sm font-semibold ${getFairColor(fairScore.total)}`}
-                  >
+                  <span className={`text-sm font-semibold ${getFairColor(fairScore.total)}`}>
                     {getFairLabel(fairScore.total)}
                   </span>
                   <p className="text-xs text-gray-400 mt-1">
@@ -422,21 +1065,14 @@ export default function NewDataset() {
                   Tips to improve your score
                 </h4>
                 <ul className="text-xs text-teal-700 space-y-1.5">
-                  <li>
-                    Write a description longer than 100 characters
-                  </li>
-                  <li>
-                    Add at least 3 tags
-                  </li>
-                  <li>
-                    List 5 or more columns
-                  </li>
-                  <li>
-                    Enable multiple access models
-                  </li>
-                  <li>
-                    Specify both date range start and end
-                  </li>
+                  <li>Write a description longer than 100 characters</li>
+                  <li>Add at least 3 tags</li>
+                  <li>List 5 or more columns/fields</li>
+                  <li>Enable multiple access models</li>
+                  <li>Specify both date range start and end</li>
+                  <li>Select a license for reusability</li>
+                  <li>Add cohort and methodology details</li>
+                  <li>Include use cases and publications</li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- **Enriched data model**: All 12 datasets now include dataTypes, fileFormats, sensitivityLevel, cohort description (hybrid structured + freetext), useCases, publications, FAQ, methodology, limitations, updateFrequency, and dataSize
- **Tabbed DatasetDetail page**: Redesigned from flat vertical layout to 8-tab interface (Overview, Details, Dictionary, Sample, Access, Use Cases, Publications, FAQ) with extracted sub-components
- **Enhanced Request Access**: Upgraded from simple modal to 3-step wizard with research context, intended data use, and file upload
- **Updated NewDataset form**: 7 collapsible sections covering all new fields with dynamic lists for use cases, publications, and FAQ
- Uses "Glass Sandbox" terminology (not TRE) throughout Access tab

## Test plan
- [ ] Navigate to `/catalog/ds-002` — verify tabbed interface with all 8 tabs
- [ ] Click each tab — verify content renders (including "Coming Soon" placeholders for Dictionary/Sample)
- [ ] Check sensitivity badge colors (red for Special Category on ds-002, amber for Pseudonymized on ds-001)
- [ ] Test Request Access wizard (3 steps) as data-user (anna.lindberg@gu.se / demo)
- [ ] Test NewDataset form as data-holder (erik.nordstrom@vgregion.se / demo)
- [ ] Verify bookmark toggle works
- [ ] Verify "Glass Sandbox" appears in Access tab
- [ ] Clear localStorage to reload enriched seed data if needed

Closes #4, closes #5, closes #6, closes #7